### PR TITLE
implement compressing vcfs by gatk, and flag to disable

### DIFF
--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -101,6 +101,9 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(fullName = "skip_annotation", shortName = "noAnnotation", doc = "Skip the snpEff annotation step", required = false)
   var skipAnnotation: Boolean = false
 
+  @Argument(fullName = "skip_vcf_compression", shortName = "noCompress", doc = "Skip gz compression of vcf files", required = false)
+  var skipVcfCompression: Boolean = false
+
   @Argument(shortName = "mbq", doc = "The minimum Phred-Scaled quality score threshold to be considered a good base in variant calling", required = false)
   var minimumBaseQuality: Int = -1
 
@@ -243,7 +246,8 @@ class DNABestPracticeVariantCalling extends QScript
         isLowPass = this.isLowPass,
         isExome = this.isExome,
         testMode = this.testMode,
-        minimumBaseQuality = this.minimumBaseQuality)
+        minimumBaseQuality = this.minimumBaseQuality,
+        skipVcfCompression = this.skipVcfCompression)
     }
 
     /**
@@ -394,7 +398,8 @@ class DNABestPracticeVariantCalling extends QScript
       snpEffPath,
       snpEffConfigPath,
       Some(snpEffReference),
-      skipAnnotation)
+      skipAnnotation,
+      skipVcfCompression)
 
     variantCallingUtils.performVariantCalling(variantCallingConfig)
   }

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -67,7 +67,8 @@ class AlignmentQCUtils(
     isLowPass: Boolean,
     isExome: Boolean,
     testMode: Boolean,
-    minimumBaseQuality: Option[Int]): Seq[File] = {
+    minimumBaseQuality: Option[Int],
+    skipVcfCompression: Boolean): Seq[File] = {
 
     val gatkOptionsWithGenotypingSnp = gatkOptions.copy(snpGenotypingVcf = Some(comparisonVcf))
     
@@ -85,7 +86,8 @@ class AlignmentQCUtils(
       testMode = testMode,
       minimumBaseQuality = minimumBaseQuality,
       noBAQ = true,
-      skipAnnotation = true)
+      skipAnnotation = true,
+      skipVcfCompression = skipVcfCompression)
 
     val concordanceFiles = variantCallingUtils.checkGenotypeConcordance(variantCallingConfig)
     concordanceFiles

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -33,6 +33,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param snpEffConfigPath  Path to snpEff config file
  * @param snpEffReference   The snpEff reference to use. E.g. "GRCh37.75"
  * @param skipAnnotation   Skip the annotation process
+ * @param skipVcfCompression    Skip compression of generated vcf files
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
@@ -52,4 +53,5 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffPath: Option[File] = None,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
-                                skipAnnotation: Boolean)
+                                skipAnnotation: Boolean,
+                                skipVcfCompression: Boolean)

--- a/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -13,17 +13,19 @@ class VariantCallingTarget(outputDir: File,
                            val isLowpass: Boolean,
                            val isExome: Boolean,
                            val nSamples: Int,
-                           val snpGenotypingVcf: Option[File] = None) {
+                           val snpGenotypingVcf: Option[File] = None,
+                           val skipVcfCompression: Boolean = true) {
 
+  val vcfExtension = if (skipVcfCompression) "vcf" else "vcf.gz"
   val name = outputDir + "/" + baseName
   val clusterFile = new File(name + ".clusters")
-  val gVCFFile = new File(name + ".genomic.vcf")
-  val rawSnpVCF = new File(name + ".raw.snp.vcf")
-  val rawIndelVCF = new File(name + ".raw.indel.vcf")
-  val rawCombinedVariants = new File(name + ".raw.vcf")
-  val filteredIndelVCF = new File(name + ".filtered.indel.vcf")
-  val recalibratedSnpVCF = new File(name + ".recalibrated.snp.vcf")
-  val recalibratedIndelVCF = new File(name + ".recalibrated.indel.vcf")
+  val gVCFFile = new File(name + ".genomic." + vcfExtension)
+  val rawSnpVCF = new File(name + ".raw.snp." + vcfExtension)
+  val rawIndelVCF = new File(name + ".raw.indel." + vcfExtension)
+  val rawCombinedVariants = new File(name + ".raw." + vcfExtension)
+  val filteredIndelVCF = new File(name + ".filtered.indel." + vcfExtension)
+  val recalibratedSnpVCF = new File(name + ".recalibrated.snp." + vcfExtension)
+  val recalibratedIndelVCF = new File(name + ".recalibrated.indel." + vcfExtension)
   val tranchesSnpFile = new File(name + ".snp.tranches")
   val tranchesIndelFile = new File(name + ".indel.tranches")
   val vqsrSnpRscript: File = new File(name + ".snp.vqsr.r")
@@ -32,6 +34,5 @@ class VariantCallingTarget(outputDir: File,
   val recalIndelFile = new File(name + ".indel.tranches.recal")
   val evalFile = new File(name + ".snp.eval")
   val evalIndelFile = new File(name + ".indel.eval")
-  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")  
-  
+  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")
 }

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -30,7 +30,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
         Seq(bam),
         gatkOptions.intervalFile,
         config.isLowPass, config.isExome, 1,
-        snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+        snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+        skipVcfCompression = config.skipVcfCompression))
 
     for (target <- targets) yield {
 
@@ -71,7 +72,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
               gatkOptions.reference,
               Seq(bam),
               gatkOptions.intervalFile,
-              config.isLowPass, config.isExome, 1)
+              config.isLowPass, config.isExome, 1,
+              skipVcfCompression = target.skipVcfCompression)
 
           config.qscript.add(new HaplotypeCallerBase(modifiedTarget, config.testMode, config.downsampleFraction, config.pcrFree, config.minimumBaseQuality))
           modifiedTarget.gVCFFile
@@ -142,13 +144,13 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
 
   /**
    * Annotated a bunch of vcf files using SnpEff - assumes all input files have
-   * a vcf file ending.
+   * a .vcf or .vcf.gz file ending.
    * @param variantFiles The variant files to annotate
    * @return The annotated versions of the files.
    */
-  def annotateUsingSnpEff(config: VariantCallingConfig, variantFiles: Seq[File]): Seq[File] = {
+  def annotateUsingSnpEff(config: VariantCallingConfig, variantFiles: Seq[File], vcfExtension: String): Seq[File] = {
     for (file <- variantFiles) yield {
-      val annotatedFile = GeneralUtils.swapExt(file.getParentFile(), file, ".vcf", ".annotated.vcf")
+      val annotatedFile = GeneralUtils.swapExt(file.getParentFile(), file, vcfExtension, "annotated." + vcfExtension)
       config.qscript.add(
         new SnpEff(file, annotatedFile, config))
       annotatedFile
@@ -172,7 +174,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           Seq(bam),
           gatkOptions.intervalFile,
           config.isLowPass, config.isExome, 1,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
 
       case (true, true) =>
         config.bams.map(bam => new VariantCallingTarget(config.outputDir,
@@ -181,7 +184,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           Seq(bam),
           gatkOptions.intervalFile,
           config.isLowPass, false, 1,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
 
       case (false, true) =>
         Seq(new VariantCallingTarget(config.outputDir,
@@ -190,7 +194,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           config.bams,
           gatkOptions.intervalFile,
           config.isLowPass, false, config.bams.size,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
 
       case (false, false) =>
         Seq(new VariantCallingTarget(config.outputDir,
@@ -199,7 +204,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           config.bams,
           gatkOptions.intervalFile,
           config.isLowPass, config.isExome, config.bams.size,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
     }
 
     // Make sure resource files are available if recalibration is to be performed
@@ -226,12 +232,14 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
         }
       })
 
-    val unannotatedVariantFiles = variantAndEvalFiles.filter(_.getName().endsWith(".vcf"))
+    val vcfExtension = targets(0).vcfExtension
+    val unannotatedVariantFiles =
+      variantAndEvalFiles.filter(_.getName().endsWith(vcfExtension))
 
     if (config.skipAnnotation)
       variantAndEvalFiles
     else
-      annotateUsingSnpEff(config, unannotatedVariantFiles) ++ variantAndEvalFiles
+      annotateUsingSnpEff(config, unannotatedVariantFiles, vcfExtension) ++ variantAndEvalFiles
   }
 
   def bai(bam: File): File = new File(bam + ".bai")


### PR DESCRIPTION
- by default, have GATK gzip-compress vcf files 
- compression can be skipped with the `--skip_vcf_compression` flag to the `DNABestPracticeVariantCalling.scala` workflow