### PR TITLE
properly skip recalibration

### DIFF
--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -99,13 +99,20 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     config.qscript.add(new SnpEvaluation(target, config.noRecal))
     config.qscript.add(new IndelEvaluation(target, config.noRecal))
 
-    Seq(
-      target.rawCombinedVariants,
-      target.recalibratedIndelVCF,
-      target.recalibratedSnpVCF,
-      target.evalFile,
-      target.evalIndelFile)
-
+    if (!config.noRecal) {
+      Seq(
+        target.rawCombinedVariants,
+        target.recalibratedIndelVCF,
+        target.recalibratedSnpVCF,
+        target.evalFile,
+        target.evalIndelFile)
+    }
+    else {
+      Seq(
+        target.rawCombinedVariants,
+        target.evalFile,
+        target.evalIndelFile)
+    }
   }
 
   /**


### PR DESCRIPTION
- Recalibrated vcf files were used in subsequent analysis results regardless if recalibration was to be stopped