### PR TITLE
Feature/reduce delivery footprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .classpath
 .project
 ~
+/bin

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -101,6 +101,9 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(fullName = "skip_annotation", shortName = "noAnnotation", doc = "Skip the snpEff annotation step", required = false)
   var skipAnnotation: Boolean = false
 
+  @Argument(fullName = "skip_vcf_compression", shortName = "noCompress", doc = "Skip gz compression of vcf files", required = false)
+  var skipVcfCompression: Boolean = false
+
   @Argument(shortName = "mbq", doc = "The minimum Phred-Scaled quality score threshold to be considered a good base in variant calling", required = false)
   var minimumBaseQuality: Int = -1
 
@@ -243,7 +246,8 @@ class DNABestPracticeVariantCalling extends QScript
         isLowPass = this.isLowPass,
         isExome = this.isExome,
         testMode = this.testMode,
-        minimumBaseQuality = this.minimumBaseQuality)
+        minimumBaseQuality = this.minimumBaseQuality,
+        skipVcfCompression = this.skipVcfCompression)
     }
 
     /**
@@ -394,7 +398,8 @@ class DNABestPracticeVariantCalling extends QScript
       snpEffPath,
       snpEffConfigPath,
       Some(snpEffReference),
-      skipAnnotation)
+      skipAnnotation,
+      skipVcfCompression)
 
     variantCallingUtils.performVariantCalling(variantCallingConfig)
   }

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -10,6 +10,7 @@ import molmed.utils.BwaMem
 import molmed.utils.GATKConfig
 import molmed.utils.GATKDataProcessingUtils
 import molmed.utils.GATKHaplotypeCaller
+import molmed.utils.GATKProcessingTarget
 import molmed.utils.GATKUnifiedGenotyper
 import molmed.utils.GeneralUtils
 import molmed.utils.MergeFilesUtils
@@ -140,6 +141,9 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(doc = "When using the --super_charge option, use this to specify number of groups (default: 3)", fullName = "ways_to_split", shortName = "wts", required = false)
   var groupsToSplitTo: Int = 3
 
+  @Argument(doc = "Do Base Quality Score Recalibration (BQSR) on-the-fly during variant calling, rather than creating base-recalibrated bam files (default)", fullName = "bqsr_otf", shortName = "botf", required = false)
+  var bqsrOnTheFly: Boolean = false
+
   /**
    * **************************************************************************
    * Hidden Parameters - for dev.
@@ -236,7 +240,7 @@ class DNABestPracticeVariantCalling extends QScript
 
     if (snpGenotypes.isDefined) {
       qualityControlUtils.checkGenotypeConcordance(
-        bams = bamFiles,
+        bamFiles = bamFiles,
         outputBase = genotypeConcordanceOutputDir,
         comparisonVcf = snpGenotypes.get,
         qscript = this,
@@ -305,12 +309,12 @@ class DNABestPracticeVariantCalling extends QScript
     gatkOptions: GATKConfig,
     generalUtils: GeneralUtils,
     uppmaxConfig: UppmaxConfig,
-    reference: File): Seq[File] = {
+    reference: File): Seq[GATKProcessingTarget] = {
 
     /**
      * Used internally to handle splitting, processing and merging.
      */
-    def runDataProcessingOnSplitByChromosomeAndMerge = {
+    def runDataProcessingOnSplitByChromosomeAndMerge: Seq[GATKProcessingTarget] = {
 
       val updateGATKOptions = gatkOptions.copy(nbrOfThreads = 16 / groupsToSplitTo)
       
@@ -319,31 +323,37 @@ class DNABestPracticeVariantCalling extends QScript
 
       val splitsBams = runChromosomeSplitting(bams, groupsToSplitTo, generalUtils, reference)
 
-      val splitAndProcessedBams =
+      val splitAndProcessedBamTargets =
         for (splitGroup <- splitsBams) yield {
-          val processedBamFiles = gatkDataProcessingUtils.dataProcessing(
+          val processedBamTargets = gatkDataProcessingUtils.dataProcessing(
             splitGroup, processedAligmentsOutputDir, cleaningModel,
             skipDeduplication = false, testMode)
-          processedBamFiles
+          processedBamTargets
         }
 
-      for (toMergeBams <- splitAndProcessedBams) yield {
+      for (toMergeBamTarget <- splitAndProcessedBamTargets) yield {
 
         // Assumes that the start of the file name is the same, and is what is to
         // be used name these files.
-        val nameOfOutputBam =
-          if (toMergeBams.size > 1) {
-            val firstFileName = toMergeBams(0).getName()
-            val secondFileName = toMergeBams(1).getName()
-            val longestCommonName =
-              firstFileName.zip(secondFileName).takeWhile(Function.tupled(_ == _)).map(_._1).mkString
-            // The splitting will add a _, removing it here.  
-            longestCommonName.stripSuffix("_")
-          } else
-            toMergeBams(0).getName().stripSuffix(".bam")
+        
+        def _longestCommonPrefix(fileNames: Seq[String]): String = {
+          if (fileNames.size > 1)
+              fileNames(0).zip(fileNames(1)).takeWhile(Function.tupled(_ == _)).map(_._1).mkString.stripSuffix("_")
+          else
+              fileNames(0).stripSuffix(".bam")
+        }
+        val nameOfOriginalBam = _longestCommonPrefix( toMergeBamTarget.map( _.bam.getName() ))
+        val mergedBamTarget = new GATKProcessingTarget(
+            processedAligmentsOutputDir, 
+            new File(processedAligmentsOutputDir + "/" + nameOfOriginalBam + ".bam"),
+            toMergeBamTarget(0).skipDeduplication,
+            toMergeBamTarget(0).bqsrOnTheFly,
+            toMergeBamTarget(0).globalIntervals)
+        SplitFilesAndMergeByChromosome.merge(qscript, toMergeBamTarget.map( _.processedBam ), mergedBamTarget.processedBam, asIntermediate = false, generalUtils)
+        SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.preRecalFile ), mergedBamTarget.preRecalFile, asIntermediate = false, generalUtils)
+        SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.postRecalFile ), mergedBamTarget.postRecalFile, asIntermediate = false, generalUtils)
 
-        val outBam = new File(processedAligmentsOutputDir + "/" + nameOfOutputBam + ".bam")
-        SplitFilesAndMergeByChromosome.merge(qscript, toMergeBams, outBam, asIntermediate = false, generalUtils)
+        mergedBamTarget
       }
     }
 
@@ -365,7 +375,7 @@ class DNABestPracticeVariantCalling extends QScript
    * Variant calling
    */
   def runVariantCalling(
-    bamFiles: Seq[File],
+    bamTargets: Seq[GATKProcessingTarget],
     outputDirectory: File,
     gatkOptions: GATKConfig,
     uppmaxConfig: UppmaxConfig): Seq[File] = {
@@ -382,7 +392,7 @@ class DNABestPracticeVariantCalling extends QScript
     val variantCallingConfig = new VariantCallingConfig(
       qscript = this,
       variantCaller = variantCallerToUse,
-      bamFiles,
+      bamTargets,
       outputDirectory,
       runSeparatly,
       isLowPass,
@@ -498,7 +508,7 @@ class DNABestPracticeVariantCalling extends QScript
       new GATKConfig(reference, nbrOfThreads, scatterGatherCount,
         intervals,
         dbSNP, Some(indels), hapmap, omni, mills, thousandGenomes,
-        notHuman)
+        notHuman, bqsrOnTheFly = bqsrOnTheFly)
 
     // Drop the version report (this will be overwritten each time the 
     // qscript is run.
@@ -537,7 +547,7 @@ class DNABestPracticeVariantCalling extends QScript
         gatkOptions, generalUtils, uppmaxConfig, reference)
 
     val variantCalling = runVariantCalling(
-      _: Seq[File], variantCallsOutputDir,
+      _: Seq[GATKProcessingTarget], variantCallsOutputDir,
       gatkOptions, uppmaxConfig)
 
     /**
@@ -573,16 +583,16 @@ class DNABestPracticeVariantCalling extends QScript
         val aligments = alignments(samples)
         val qc = qualityControl(aligments.values.flatten.toSeq, preliminaryAlignmentQCOutputDir)
         val mergedBams = mergedAlignments(aligments)
-        val processedBams = dataProcessing(mergedBams)
-        qualityControl(processedBams, finalAlignmentQCOutputDir)
+        val processedBamTargets = dataProcessing(mergedBams)
+        qualityControl(processedBamTargets.map( _.processedBam ), finalAlignmentQCOutputDir)
       }
       case e if e.contains(AnalysisSteps.VariantCalling) => {
         val aligments = alignments(samples)
         val qc = qualityControl(aligments.values.flatten.toSeq, preliminaryAlignmentQCOutputDir)
         val mergedBams = mergedAlignments(aligments)
-        val processedBams = dataProcessing(mergedBams)
-        qualityControl(processedBams, finalAlignmentQCOutputDir)
-        variantCalling(processedBams)
+        val processedBamTargets = dataProcessing(mergedBams)
+        qualityControl(processedBamTargets.map( _.processedBam ), finalAlignmentQCOutputDir)
+        variantCalling(processedBamTargets)
       }
       case e if e.contains(AnalysisSteps.GenerateDelivery) => {
 
@@ -594,13 +604,13 @@ class DNABestPracticeVariantCalling extends QScript
         val aligments = alignments(samples)
         val preliminaryQC = qualityControl(aligments.values.flatten.toSeq, preliminaryAlignmentQCOutputDir)
         val mergedBams = mergedAlignments(aligments)
-        val processedBams = dataProcessing(mergedBams)
-        val finalQC = qualityControl(processedBams, finalAlignmentQCOutputDir)
-        val variantCallFiles = variantCalling(processedBams)
+        val processedBamTargets = dataProcessing(mergedBams)
+        val finalQC = qualityControl(processedBamTargets.map( _.processedBam ), finalAlignmentQCOutputDir)
+        val variantCallFiles = variantCalling(processedBamTargets)
 
         runCreateDelivery(
           fastqs,
-          processedBams,
+          processedBamTargets.map( _.processedBam ),
           finalQC,
           variantCallFiles,
           reportFile,

--- a/src/main/scala/molmed/report/ReportGenerator.scala
+++ b/src/main/scala/molmed/report/ReportGenerator.scala
@@ -165,7 +165,7 @@ Piper is a pipeline system developed and maintained at the National Genomics Inf
     val qualimapVersion = fileVersionFromKey(resourceMap, Constants.QUALIMAP)
     val gatkVersion = getGATKVersion()
     val snpEffVersion = fileVersionFromKey(resourceMap, Constants.SNP_EFF)
-
+    val snpEffReference = fileVersionFromKey(resourceMap, Constants.SNP_EFF_REFERENCE)
     val referenceName = reference.getName()
     val dbSNPVersion = fileVersionFromKey(resourceMap, Constants.DB_SNP)
     val thousandGenomesIndelsVersion = fileVersionFromKey(resourceMap, Constants.THOUSAND_GENOMES)
@@ -192,6 +192,7 @@ bwa: $bwaVersion
 samtools: $samtoolsVersion
 qualimap: $qualimapVersion
 snpEff: $snpEffVersion
+snpEff reference: $snpEffReference
 gatk: $gatkVersion
 
 reference: $referenceName

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -67,7 +67,8 @@ class AlignmentQCUtils(
     isLowPass: Boolean,
     isExome: Boolean,
     testMode: Boolean,
-    minimumBaseQuality: Option[Int]): Seq[File] = {
+    minimumBaseQuality: Option[Int],
+    skipVcfCompression: Boolean): Seq[File] = {
 
     val gatkOptionsWithGenotypingSnp = gatkOptions.copy(snpGenotypingVcf = Some(comparisonVcf))
     
@@ -85,7 +86,8 @@ class AlignmentQCUtils(
       testMode = testMode,
       minimumBaseQuality = minimumBaseQuality,
       noBAQ = true,
-      skipAnnotation = true)
+      skipAnnotation = true,
+      skipVcfCompression = skipVcfCompression)
 
     val concordanceFiles = variantCallingUtils.checkGenotypeConcordance(variantCallingConfig)
     concordanceFiles

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -57,7 +57,7 @@ class AlignmentQCUtils(
    *
    */
   def checkGenotypeConcordance(
-    bams: Seq[File],
+    bamFiles: Seq[File],
     outputBase: File,
     comparisonVcf: File,
     qscript: QScript,
@@ -71,12 +71,17 @@ class AlignmentQCUtils(
     skipVcfCompression: Boolean): Seq[File] = {
 
     val gatkOptionsWithGenotypingSnp = gatkOptions.copy(snpGenotypingVcf = Some(comparisonVcf))
-    
+    val bamTargets = bamFiles.map( bamFile => new GATKProcessingTarget(
+          bamFile.getParentFile(),
+          bamFile,
+          skipDeduplication = false,
+          gatkOptions.bqsrOnTheFly,
+          gatkOptions.intervalFile) )
     val variantCallingUtils = new VariantCallingUtils(gatkOptionsWithGenotypingSnp, projectName, uppmaxConfig)
     val variantCallingConfig = new VariantCallingConfig(
       qscript = qscript,
       variantCaller = Some(GATKUnifiedGenotyper),
-      bams = bams,
+      bamTargets = bamTargets,
       outputDir = outputBase,
       runSeparatly = true,
       isLowPass = isLowPass,

--- a/src/main/scala/molmed/utils/GATKConfig.scala
+++ b/src/main/scala/molmed/utils/GATKConfig.scala
@@ -17,4 +17,5 @@ case class GATKConfig(
   mills: Option[File] = None,
   thousandGenomes: Option[File] = None,
   notHuman: Boolean = false,
-  snpGenotypingVcf: Option[File] = None)
+  snpGenotypingVcf: Option[File] = None,
+  bqsrOnTheFly: Boolean = false)

--- a/src/main/scala/molmed/utils/GATKProcessingTarget.scala
+++ b/src/main/scala/molmed/utils/GATKProcessingTarget.scala
@@ -1,0 +1,31 @@
+package molmed.utils
+
+import java.io.File
+import org.broadinstitute.gatk.tools.walkers.indels.IndelRealigner.ConsensusDeterminationModel
+
+/**
+ * Help class handling each GATK processing target. Storing input files, creating output filenames etc.
+ */
+class GATKProcessingTarget(outputDir: File,
+                           val bam: File,
+                           val skipDeduplication: Boolean,
+                           val bqsrOnTheFly: Boolean,
+                           val globalIntervals: Option[File]) {
+
+    // Processed bam files
+    val cleanedBam = GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam")
+    val dedupedBam = if (!skipDeduplication) GeneralUtils.swapExt(outputDir, cleanedBam, ".bam", ".dedup.bam") else cleanedBam
+    val recalBam = GeneralUtils.swapExt(outputDir, dedupedBam, ".bam", ".recal.bam")
+    val processedBam = if (!bqsrOnTheFly) recalBam else dedupedBam
+
+    // Accessory files
+    val targetIntervals = globalIntervals.getOrElse(GeneralUtils.swapExt(outputDir, bam, ".bam", ".intervals"))
+    val metricsFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".metrics")
+    val preRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre_recal.table")
+    val postRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post_recal.table")
+    val preOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre")
+    val postOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post")
+    val preValidateLog = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre.validation")
+    val postValidateLog = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post.validation")
+
+}

--- a/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/src/main/scala/molmed/utils/GATKUtils.scala
@@ -70,7 +70,7 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
 
   }
 
-  case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
+  case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String, inRecalFile: Option[File] = None) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
 
     this.num_cpu_threads_per_data_thread = gatkOptions.nbrOfThreads
 
@@ -84,6 +84,8 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
     if (!gatkOptions.intervalFile.isEmpty) this.intervals :+= gatkOptions.intervalFile.get
 
     this.scatterCount = gatkOptions.scatterGatherCount.get
+    if (!inRecalFile.isEmpty)
+      this.BQSR = inRecalFile.get
     override def jobRunnerJobName = projectName.get + "_cov"
 
   }
@@ -101,7 +103,6 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
     this.out = outBam
     this.scatterCount = gatkOptions.scatterGatherCount.get
     this.num_cpu_threads_per_data_thread = gatkOptions.nbrOfThreads
-    this.isIntermediate = false
     override def jobRunnerJobName = projectName.get + "_recal"
 
   }

--- a/src/main/scala/molmed/utils/GeneralUtils.scala
+++ b/src/main/scala/molmed/utils/GeneralUtils.scala
@@ -17,6 +17,8 @@ import org.broadinstitute.gatk.queue.extensions.picard.ValidateSamFile
 import org.broadinstitute.gatk.queue.function.InProcessFunction
 import org.broadinstitute.gatk.queue.function.ListWriterFunction
 import org.broadinstitute.gatk.queue.util.StringFileConversions
+import org.broadinstitute.gatk.tools.walkers.bqsr.BQSRGatherer
+
 
 import htsjdk.samtools.SAMFileHeader.SortOrder
 import molmed.queue.extensions.RNAQC.RNASeQC
@@ -365,6 +367,24 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     override def jobRunnerJobName = projectName.get + "_collectHSMetrics"
 
   }
+
+  /**
+   * Merge BQSR recalibration tables
+   *
+   * @param inRecalFiles Seq of recalibration table files to merge
+   * @param outRecalFile the merged output recalibration table file
+   */
+  case class mergeRecalibrationTables(@Input inRecalFiles: Seq[File], @Output outRecalFile: File, asIntermediate: Boolean = false) extends InProcessFunction {
+    import scala.collection.JavaConverters._
+
+    this.isIntermediate = asIntermediate
+
+    def run() {
+      new BQSRGatherer().gather(inRecalFiles.toList.asJava, outRecalFile)
+    }
+
+  }
+
 }
 
 /**

--- a/src/main/scala/molmed/utils/SplitFilesAndMergeByChromosome.scala
+++ b/src/main/scala/molmed/utils/SplitFilesAndMergeByChromosome.scala
@@ -145,4 +145,27 @@ object SplitFilesAndMergeByChromosome {
     outBam
   }
 
+  /**
+   * Merge a set of recalibration table files
+   *
+   * @param qscript
+   * @param inRecalTables
+   * @param outRecalTable
+   * @param asIntermediate
+   * @param generalUtils
+   * @return The merged file
+   */
+  def mergeRecalibrationTables(
+    qscript: QScript,
+    inRecalTables: Seq[File],
+    outRecalTable: File,
+    asIntermediate: Boolean,
+    generalUtils: GeneralUtils): File = {
+
+    qscript.add(
+      generalUtils.mergeRecalibrationTables(inRecalTables, outRecalTable, asIntermediate = asIntermediate))
+
+    outRecalTable
+  }
+
 }

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -33,6 +33,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param snpEffConfigPath  Path to snpEff config file
  * @param snpEffReference   The snpEff reference to use. E.g. "GRCh37.75"
  * @param skipAnnotation   Skip the annotation process
+ * @param skipVcfCompression    Skip compression of generated vcf files
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
@@ -52,4 +53,5 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffPath: Option[File] = None,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
-                                skipAnnotation: Boolean)
+                                skipAnnotation: Boolean,
+                                skipVcfCompression: Boolean)

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -16,7 +16,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param	qscript				the qscript to run the commandline wrappers in
  * @param variantCaller		The type of variant caller to use. Options are UnifiedGenotyper and HaplotypeCaller.
  * 							(default: HaplotypeCaller)
- * @param bams				the bam files to run on
+ * @param bamTargets				the bam file targets to run on
  * @param outputDir			output dir
  * @param runSeparatly		Create one vcf per bam sample instead of running on full cohort
  * @param isLowPass			true if low pass
@@ -37,7 +37,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
-                                bams: Seq[File],
+                                bamTargets: Seq[GATKProcessingTarget],
                                 outputDir: File,
                                 runSeparatly: Boolean,
                                 isLowPass: Boolean,

--- a/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -13,17 +13,19 @@ class VariantCallingTarget(outputDir: File,
                            val isLowpass: Boolean,
                            val isExome: Boolean,
                            val nSamples: Int,
-                           val snpGenotypingVcf: Option[File] = None) {
+                           val snpGenotypingVcf: Option[File] = None,
+                           val skipVcfCompression: Boolean = true) {
 
+  val vcfExtension = if (skipVcfCompression) "vcf" else "vcf.gz"
   val name = outputDir + "/" + baseName
   val clusterFile = new File(name + ".clusters")
-  val gVCFFile = new File(name + ".genomic.vcf")
-  val rawSnpVCF = new File(name + ".raw.snp.vcf")
-  val rawIndelVCF = new File(name + ".raw.indel.vcf")
-  val rawCombinedVariants = new File(name + ".raw.vcf")
-  val filteredIndelVCF = new File(name + ".filtered.indel.vcf")
-  val recalibratedSnpVCF = new File(name + ".recalibrated.snp.vcf")
-  val recalibratedIndelVCF = new File(name + ".recalibrated.indel.vcf")
+  val gVCFFile = new File(name + ".genomic." + vcfExtension)
+  val rawSnpVCF = new File(name + ".raw.snp." + vcfExtension)
+  val rawIndelVCF = new File(name + ".raw.indel." + vcfExtension)
+  val rawCombinedVariants = new File(name + ".raw." + vcfExtension)
+  val filteredIndelVCF = new File(name + ".filtered.indel." + vcfExtension)
+  val recalibratedSnpVCF = new File(name + ".recalibrated.snp." + vcfExtension)
+  val recalibratedIndelVCF = new File(name + ".recalibrated.indel." + vcfExtension)
   val tranchesSnpFile = new File(name + ".snp.tranches")
   val tranchesIndelFile = new File(name + ".indel.tranches")
   val vqsrSnpRscript: File = new File(name + ".snp.vqsr.r")
@@ -32,6 +34,5 @@ class VariantCallingTarget(outputDir: File,
   val recalIndelFile = new File(name + ".indel.tranches.recal")
   val evalFile = new File(name + ".snp.eval")
   val evalIndelFile = new File(name + ".indel.eval")
-  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")  
-  
+  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")
 }

--- a/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -8,7 +8,7 @@ import java.io.File
 class VariantCallingTarget(outputDir: File,
                            val baseName: String,
                            val reference: File,
-                           val bamList: Seq[File],
+                           val bamTargetList: Seq[GATKProcessingTarget],
                            val intervals: Option[File],
                            val isLowpass: Boolean,
                            val isExome: Boolean,

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -30,7 +30,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
         Seq(bam),
         gatkOptions.intervalFile,
         config.isLowPass, config.isExome, 1,
-        snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+        snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+        skipVcfCompression = config.skipVcfCompression))
 
     for (target <- targets) yield {
 
@@ -71,7 +72,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
               gatkOptions.reference,
               Seq(bam),
               gatkOptions.intervalFile,
-              config.isLowPass, config.isExome, 1)
+              config.isLowPass, config.isExome, 1,
+              skipVcfCompression = target.skipVcfCompression)
 
           config.qscript.add(new HaplotypeCallerBase(modifiedTarget, config.testMode, config.downsampleFraction, config.pcrFree, config.minimumBaseQuality))
           modifiedTarget.gVCFFile
@@ -149,13 +151,13 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
 
   /**
    * Annotated a bunch of vcf files using SnpEff - assumes all input files have
-   * a vcf file ending.
+   * a .vcf or .vcf.gz file ending.
    * @param variantFiles The variant files to annotate
    * @return The annotated versions of the files.
    */
-  def annotateUsingSnpEff(config: VariantCallingConfig, variantFiles: Seq[File]): Seq[File] = {
+  def annotateUsingSnpEff(config: VariantCallingConfig, variantFiles: Seq[File], vcfExtension: String): Seq[File] = {
     for (file <- variantFiles) yield {
-      val annotatedFile = GeneralUtils.swapExt(file.getParentFile(), file, ".vcf", ".annotated.vcf")
+      val annotatedFile = GeneralUtils.swapExt(file.getParentFile(), file, vcfExtension, "annotated." + vcfExtension)
       config.qscript.add(
         new SnpEff(file, annotatedFile, config))
       annotatedFile
@@ -179,7 +181,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           Seq(bam),
           gatkOptions.intervalFile,
           config.isLowPass, config.isExome, 1,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
 
       case (true, true) =>
         config.bams.map(bam => new VariantCallingTarget(config.outputDir,
@@ -188,7 +191,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           Seq(bam),
           gatkOptions.intervalFile,
           config.isLowPass, false, 1,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
 
       case (false, true) =>
         Seq(new VariantCallingTarget(config.outputDir,
@@ -197,7 +201,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           config.bams,
           gatkOptions.intervalFile,
           config.isLowPass, false, config.bams.size,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
 
       case (false, false) =>
         Seq(new VariantCallingTarget(config.outputDir,
@@ -206,7 +211,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
           config.bams,
           gatkOptions.intervalFile,
           config.isLowPass, config.isExome, config.bams.size,
-          snpGenotypingVcf = gatkOptions.snpGenotypingVcf))
+          snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
+          skipVcfCompression = config.skipVcfCompression))
     }
 
     // Make sure resource files are available if recalibration is to be performed
@@ -233,12 +239,14 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
         }
       })
 
-    val unannotatedVariantFiles = variantAndEvalFiles.filter(_.getName().endsWith(".vcf"))
+    val vcfExtension = targets(0).vcfExtension
+    val unannotatedVariantFiles =
+      variantAndEvalFiles.filter(_.getName().endsWith(vcfExtension))
 
     if (config.skipAnnotation)
       variantAndEvalFiles
     else
-      annotateUsingSnpEff(config, unannotatedVariantFiles) ++ variantAndEvalFiles
+      annotateUsingSnpEff(config, unannotatedVariantFiles, vcfExtension) ++ variantAndEvalFiles
   }
 
   def bai(bam: File): File = new File(bam + ".bai")

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -285,7 +285,7 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
       this.min_base_quality_score = Some(min_base_quality_score.get.toByte)
 
     if (bqsrOnTheFly.getOrElse(false)) 
-      this.BQSR = t.bamTargetList.map( _.preRecalFile )
+      this.BQSR = t.bamTargetList(0).preRecalFile
       
     this.input_file = t.bamTargetList.map( _.processedBam )
     this.out = t.gVCFFile
@@ -390,7 +390,7 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     if (!gatkOptions.dbSNP.isEmpty)
       this.D = gatkOptions.dbSNP.get
     if (bqsrOnTheFly.getOrElse(false))
-      this.BQSR = t.bamTargetList.map( _.preRecalFile )
+      this.BQSR = t.bamTargetList(0).preRecalFile
   }
 
   // 1a.) Call SNPs with UG


### PR DESCRIPTION
- gzip-compress all vcf files (with GATK) by default (implements #66)
- don't output base quality score recalibrated (BQSR) bam-file but perform BQSR on-the-fly instead (activated with the `--bqsr_onthefly` flag)
- include the snpEff reference version in `version_report.txt` 