### PR TITLE
Feature/reduce delivery footprint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ scala:
    - "2.9.2"
 jdk:
    - oraclejdk7
-   - openjdk7
 before_install: export SBT_OPTS="-Xms1536m -Xmx1536m -XX:MaxPermSize=384m -XX:ReservedCodeCacheSize=192m"
 install: ./setup.sh
 script: sbt/bin/sbt test 

--- a/globalConfig.xml
+++ b/globalConfig.xml
@@ -49,7 +49,12 @@
         <program>
             <name>snpEff</name>
             <path>/data/programs/snpEff/snpEff</path>
-	    <version>4.0</version>
+            <version>4.0</version>
+        </program>
+        <program>
+            <name>bcftools</name>
+            <path>/data/programs/bcftools/bcftools</path>
+            <version>1.2</version>
         </program>
     </programs>
     <resources>

--- a/src/main/scala/molmed/config/Constants.scala
+++ b/src/main/scala/molmed/config/Constants.scala
@@ -19,6 +19,7 @@ object Constants {
   val CUTADAPT = "cutadapt"
   val TOPHAP = "tophat"
   val SNP_EFF = "snpEff"
+  val BCFTOOLS = "bcftools"
 
   val DB_SNP = "dbsnp"
   val INDELS = "indels"

--- a/src/main/scala/molmed/config/FileAndProgramResourceConfig.scala
+++ b/src/main/scala/molmed/config/FileAndProgramResourceConfig.scala
@@ -78,6 +78,9 @@ trait FileAndProgramResourceConfig {
   @Input(doc = "The path to the start-up script of snpEff", fullName = "path_to_snpeff", shortName = "snpEff", required = false)
   var snpEffPath: File = _
 
+  @Input(doc = "The path to the binary of bcftools", fullName = "path_to_bcftools", shortName = "bcftools", required = false)
+  var bcftoolsPath: File = _
+
   // Please not that this has no override in the xml file, but has to be overriden from the commandline if this is necessary.
   @Argument(doc = "The path to snpEff config", fullName = "path_to_snpeff_config", shortName = "snpEffConf", required = false)
   var snpEffConfigPath: File = _
@@ -262,6 +265,9 @@ trait FileAndProgramResourceConfig {
 
       if (this.snpEffPath == null)
         this.snpEffPath = getFileFromKey(programNameToPathsMap, Constants.SNP_EFF)
+
+      if (this.bcftoolsPath == null)
+        this.bcftoolsPath = getFileFromKey(programNameToPathsMap, Constants.BCFTOOLS)
 
       programNameToPathsMap
 

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -409,7 +409,8 @@ class DNABestPracticeVariantCalling extends QScript
       snpEffConfigPath,
       Some(snpEffReference),
       skipAnnotation,
-      skipVcfCompression)
+      skipVcfCompression,
+      bcftoolsPath)
 
     variantCallingUtils.performVariantCalling(variantCallingConfig)
   }

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -325,7 +325,7 @@ class DNABestPracticeVariantCalling extends QScript
       val updateGATKOptions = gatkOptions.copy(nbrOfThreads = 16 / groupsToSplitTo)
       
       val gatkDataProcessingUtils = new GATKDataProcessingUtils(
-        this, gatkOptions, generalUtils, projectName, uppmaxConfig)
+        this, updateGATKOptions, generalUtils, projectName, uppmaxConfig)
 
       val splitsBams = runChromosomeSplitting(bams, groupsToSplitTo, generalUtils, reference)
 

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -363,6 +363,9 @@ class DNABestPracticeVariantCalling extends QScript
         // Merge the covariate tables
         SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.preRecalFile ), mergedBamTarget.preRecalFile, asIntermediate = false, generalUtils)
         SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.postRecalFile ), mergedBamTarget.postRecalFile, asIntermediate = false, generalUtils)
+        // Analyze the covariates and plot
+        // TODO: disable this for now because of R dependencies missing (ggplot2)
+        // this.add(gatkDataProcessingUtils.analyze(mergedBamTarget.preRecalFile, mergedBamTarget.postRecalFile, mergedBamTarget.covariatesPlotFile, asIntermediate = false))
         // Unfortunately, we need to re-run MarkDuplicates in order to produce metrics representing the merged files
         if (!mergedBamTarget.skipDeduplication)
           this.add(generalUtils.dedupMetrics(mergedBamTarget.processedBam.file, mergedBamTarget.metricsFile))

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -141,7 +141,7 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(doc = "When using the --super_charge option, use this to specify number of groups (default: 3)", fullName = "ways_to_split", shortName = "wts", required = false)
   var groupsToSplitTo: Int = 3
 
-  @Argument(doc = "Keep the BAM files from before the BQSR step", fullName = "keep_pre_bqsr_bam", shortName = "keepBam", required = false)
+  @Argument(doc = "Keep the BAM files from before the BQSR step instead of the BAM file from after the BQSR step", fullName = "keep_pre_bqsr_bam", shortName = "keepBam", required = false)
   var keepPreBQSRBam: Boolean = false
 
   @Argument(doc = "Disable emitting the insertion and deletion qualities in the BQSR step", fullName = "disable_indel_quals", shortName = "noIndelQuals", required = false)

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -141,8 +141,14 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(doc = "When using the --super_charge option, use this to specify number of groups (default: 3)", fullName = "ways_to_split", shortName = "wts", required = false)
   var groupsToSplitTo: Int = 3
 
-  @Argument(doc = "Do Base Quality Score Recalibration (BQSR) on-the-fly during variant calling, rather than creating base-recalibrated bam files (default)", fullName = "bqsr_otf", shortName = "botf", required = false)
-  var bqsrOnTheFly: Boolean = false
+  @Argument(doc = "Keep the BAM files from before the BQSR step", fullName = "keep_pre_bqsr_bam", shortName = "keepBam", required = false)
+  var keepPreBQSRBam: Boolean = false
+
+  @Argument(doc = "Disable emitting the insertion and deletion qualities in the BQSR step", fullName = "disable_indel_quals", shortName = "noIndelQuals", required = false)
+  var disableIndelQuals: Boolean = false
+
+  @Argument(doc = "Emit the original qualities in the BQSR step", fullName = "emit_original_quals", shortName = "orgQuals", required = false)
+  var emitOriginalQuals: Boolean = false
 
   /**
    * **************************************************************************
@@ -347,7 +353,6 @@ class DNABestPracticeVariantCalling extends QScript
             processedAligmentsOutputDir, 
             new File(processedAligmentsOutputDir + "/" + nameOfOriginalBam + ".bam"),
             toMergeBamTarget(0).skipDeduplication,
-            toMergeBamTarget(0).bqsrOnTheFly,
             toMergeBamTarget(0).globalIntervals)
         SplitFilesAndMergeByChromosome.merge(qscript, toMergeBamTarget.map( _.processedBam ), mergedBamTarget.processedBam, asIntermediate = false, generalUtils)
         SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.preRecalFile ), mergedBamTarget.preRecalFile, asIntermediate = false, generalUtils)
@@ -509,7 +514,8 @@ class DNABestPracticeVariantCalling extends QScript
       new GATKConfig(reference, nbrOfThreads, scatterGatherCount,
         intervals,
         dbSNP, Some(indels), hapmap, omni, mills, thousandGenomes,
-        notHuman, bqsrOnTheFly = bqsrOnTheFly)
+        notHuman, keepPreBQSRBam = keepPreBQSRBam,
+        disableIndelQuals = disableIndelQuals, emitOriginalQuals = emitOriginalQuals)
 
     // Drop the version report (this will be overwritten each time the 
     // qscript is run.

--- a/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
@@ -122,7 +122,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
 
     val intervalOption = if(intervals == null) None else Some(intervals) 
     
-    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, bqsrOnTheFly = false, intervalOption) )
+    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, intervalOption) )
     
     val targets = (runSeparatly, notHuman) match {
       case (true, false) => bamTargets.map(bamTarget => new VariantCallingTarget(outputDir, bamTarget.bam.getName(), reference, Seq(bamTarget), intervalOption, isLowpass, isExome, 1))
@@ -135,7 +135,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
       if (!skipCalling) {
         if (!noIndels) {
           // Indel calling, recalibration and evaulation
-          add(new variantCallingUtils.UnifiedGenotyperIndelCall(target, testMode, downsampleFraction, Some(false)))
+          add(new variantCallingUtils.UnifiedGenotyperIndelCall(target, testMode, downsampleFraction))
           if (!noRecal) {
             add(new variantCallingUtils.IndelRecalibration(target))
             add(new variantCallingUtils.IndelCut(target))
@@ -143,7 +143,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
           }
         }
         // SNP calling, recalibration and evaluation
-        add(new variantCallingUtils.UnifiedGenotyperSnpCall(target, testMode, downsampleFraction, minimumBaseQuality, deletions, noBAQ, Some(false)))
+        add(new variantCallingUtils.UnifiedGenotyperSnpCall(target, testMode, downsampleFraction, minimumBaseQuality, deletions, noBAQ))
         if (!noRecal) {
           add(new variantCallingUtils.SnpRecalibration(target))
           add(new variantCallingUtils.SnpCut(target))

--- a/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
@@ -122,7 +122,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
 
     val intervalOption = if(intervals == null) None else Some(intervals) 
     
-    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, intervalOption) )
+    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, gatkOptions.keepPreBQSRBam, intervalOption) )
     
     val targets = (runSeparatly, notHuman) match {
       case (true, false) => bamTargets.map(bamTarget => new VariantCallingTarget(outputDir, bamTarget.bam.getName(), reference, Seq(bamTarget), intervalOption, isLowpass, isExome, 1))

--- a/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
+++ b/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
@@ -99,9 +99,10 @@ class MarkDuplicates extends MarkDuplicatesWrapper {
 class MarkDuplicatesMetrics extends MarkDuplicatesWrapper {
 
   var output: File = new File("/dev/null")
-  var outputIndex: File = new File("/dev/null")
 
   @Output(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
   var metrics: File = _
+
+  this.createIndex = Some(false)
 
 }

--- a/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
+++ b/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
@@ -32,27 +32,21 @@ import org.broadinstitute.gatk.queue.function.JavaCommandLineFunction
 
 import molmed.utils.GeneralUtils
 
+
 /**
  * This MarkDuplicates extention is identical to the one provided with GATK
- * Queue with the exception that the metrics file is not annotated as a output,
- * but rather as an argument. This means it will not be removed if there the
- * class is added as an intermediate step in your pipeline.
+ * Queue with the exception that the annotations for the output, outputIndex and
+ * metrics files are left to subclasses extending this wrapper.
  */
-class MarkDuplicates extends JavaCommandLineFunction with PicardBamFunction {
+trait MarkDuplicatesWrapper extends JavaCommandLineFunction with PicardBamFunction {
   analysisName = "MarkDuplicates"
   javaMainClass = "picard.sam.MarkDuplicates"
 
+  var output: File
+  var metrics: File
+
   @Input(doc="The input SAM or BAM files to analyze.  Must be coordinate sorted.", shortName = "input", fullName = "input_bam_files", required = true)
   var input: Seq[File] = Nil
-
-  @Output(doc="The output file to write marked records to", shortName = "output", fullName = "output_bam_file", required = true)
-  var output: File = _
-
-  @Output(doc="The output bam index", shortName = "out_index", fullName = "output_bam_index_file", required = false)
-  var outputIndex: File = _
-
-  @Argument(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
-  var metrics: File = new File(output + ".metrics")
 
   @Argument(doc="If true do not write duplicates to the output file instead of writing them with appropriate flags set.", shortName = "remdup", fullName = "remove_duplicates", required = false)
   var REMOVE_DUPLICATES: Boolean = false
@@ -63,20 +57,51 @@ class MarkDuplicates extends JavaCommandLineFunction with PicardBamFunction {
   @Argument(doc = "This number, plus the maximum RAM available to the JVM, determine the memory footprint used by some of the sorting collections.  If you are running out of memory, try reducing this number.", shortName = "sorting_ratio", fullName = "sorting_collection_size_ratio", required = false)
   var SORTING_COLLECTION_SIZE_RATIO: Double = -1
 
-  override def freezeFieldValues() {
-    super.freezeFieldValues()
-    if (outputIndex == null && output != null)
-      outputIndex = GeneralUtils.swapExt(output.getParentFile, output, ".bam", ".bam.bai")
-  }
-
-
   override def inputBams = input
   override def outputBam = output
   this.sortOrder = null
   this.createIndex = Some(true)
   override def commandLine = super.commandLine +
-                             required("M=" + metrics) +
-                             conditional(REMOVE_DUPLICATES, "REMOVE_DUPLICATES=true") +
-                             conditional(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP > 0, "MAX_FILE_HANDLES_FOR_READ_ENDS_MAP=" + MAX_FILE_HANDLES_FOR_READ_ENDS_MAP.toString) +
-                             conditional(SORTING_COLLECTION_SIZE_RATIO > 0, "SORTING_COLLECTION_SIZE_RATIO=" + SORTING_COLLECTION_SIZE_RATIO.toString)
+    required("M=" + metrics) +
+    conditional(REMOVE_DUPLICATES, "REMOVE_DUPLICATES=true") +
+    conditional(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP > 0, "MAX_FILE_HANDLES_FOR_READ_ENDS_MAP=" + MAX_FILE_HANDLES_FOR_READ_ENDS_MAP.toString) +
+    conditional(SORTING_COLLECTION_SIZE_RATIO > 0, "SORTING_COLLECTION_SIZE_RATIO=" + SORTING_COLLECTION_SIZE_RATIO.toString)
+}
+
+/**
+ * This MarkDuplicates extention extends the wrapper above and annotates the metrics file as an argument
+ * instead of as an output. This means it will not be removed if there the
+ * class is added as an intermediate step in your pipeline. Otherwise, the functionality is identical
+ * to the MarkDuplicates extension supplied with GATK.
+ */
+class MarkDuplicates extends MarkDuplicatesWrapper {
+
+  @Output(doc="The output file to write marked records to", shortName = "output", fullName = "output_bam_file", required = true)
+  var output: File = _
+
+  @Output(doc="The output bam index", shortName = "out_index", fullName = "output_bam_index_file", required = false)
+  var outputIndex: File = _
+
+  @Argument(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
+  var metrics: File = new File(output + ".metrics")
+
+  override def freezeFieldValues() {
+    super.freezeFieldValues()
+    if (outputIndex == null && output != null)
+      outputIndex = new File(output.getName.stripSuffix(".bam") + ".bai")
+  }
+}
+
+/**
+ * This MarkDuplicates extention extends the wrapper above and discards the output and outputIndex,
+ * just generating and keeping the metrics file (as an output). NB: this behaviour is Unix-specific.
+ */
+class MarkDuplicatesMetrics extends MarkDuplicatesWrapper {
+
+  var output: File = new File("/dev/null")
+  var outputIndex: File = new File("/dev/null")
+
+  @Output(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
+  var metrics: File = _
+
 }

--- a/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
+++ b/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
@@ -30,6 +30,8 @@ import java.io.File
 import org.broadinstitute.gatk.queue.extensions.picard.PicardBamFunction
 import org.broadinstitute.gatk.queue.function.JavaCommandLineFunction
 
+import molmed.utils.GeneralUtils
+
 /**
  * This MarkDuplicates extention is identical to the one provided with GATK
  * Queue with the exception that the metrics file is not annotated as a output,
@@ -64,7 +66,7 @@ class MarkDuplicates extends JavaCommandLineFunction with PicardBamFunction {
   override def freezeFieldValues() {
     super.freezeFieldValues()
     if (outputIndex == null && output != null)
-      outputIndex = new File(output.getName.stripSuffix(".bam") + ".bai")
+      outputIndex = GeneralUtils.swapExt(output.getParentFile, output, ".bam", ".bam.bai")
   }
 
 

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -75,6 +75,7 @@ class AlignmentQCUtils(
           bamFile.getParentFile(),
           bamFile,
           skipDeduplication = false,
+          keepPreBQSRBam = false,
           gatkOptions.intervalFile) )
     val variantCallingUtils = new VariantCallingUtils(gatkOptionsWithGenotypingSnp, projectName, uppmaxConfig)
     val variantCallingConfig = new VariantCallingConfig(

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -75,7 +75,6 @@ class AlignmentQCUtils(
           bamFile.getParentFile(),
           bamFile,
           skipDeduplication = false,
-          gatkOptions.bqsrOnTheFly,
           gatkOptions.intervalFile) )
     val variantCallingUtils = new VariantCallingUtils(gatkOptionsWithGenotypingSnp, projectName, uppmaxConfig)
     val variantCallingConfig = new VariantCallingConfig(

--- a/src/main/scala/molmed/utils/AlignmentUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentUtils.scala
@@ -276,6 +276,8 @@ class BwaAlignmentUtils(qscript: QScript, bwaPath: String, bwaThreads: Int, samt
     @Input(doc = "fastq file with mate 2 file to be aligned") var mate2 = fastq2
     @Input(doc = "reference") var ref = reference
     @Output(doc = "output aligned bam file") var alignedBam = outBam
+    @Output(doc = "output aligned bam index file") var bamIndex = GeneralUtils.swapExt(
+      outBam.getParentFile, outBam, ".bam", ".bam.bai")
 
     // The output from this is a samfile, which can be removed later
     this.isIntermediate = intermediate

--- a/src/main/scala/molmed/utils/GATKConfig.scala
+++ b/src/main/scala/molmed/utils/GATKConfig.scala
@@ -18,4 +18,6 @@ case class GATKConfig(
   thousandGenomes: Option[File] = None,
   notHuman: Boolean = false,
   snpGenotypingVcf: Option[File] = None,
-  bqsrOnTheFly: Boolean = false)
+  keepPreBQSRBam: Boolean = false,
+  disableIndelQuals: Boolean = false,
+  emitOriginalQuals: Boolean = false)

--- a/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
+++ b/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
@@ -71,11 +71,15 @@ class GATKDataProcessingUtils(
             qscript.add(generalUtils.dedup(processedTarget.cleanedBam, processedTarget.dedupedBam, processedTarget.metricsFile, asIntermediate = !this.gatkOptions.bqsrOnTheFly))
         // calculate recalibration covariates
         qscript.add(cov(processedTarget.dedupedBam, processedTarget.preRecalFile, defaultPlatform = ""))
-        // calculate recalibration covariates after recalibration
-        qscript.add(cov(processedTarget.dedupedBam, processedTarget.postRecalFile, defaultPlatform = "", Some(processedTarget.preRecalFile)))
         // apply recalibration unless we should do it on-the-fly
-        if (!this.gatkOptions.bqsrOnTheFly)
-            qscript.add(recal(processedTarget.dedupedBam, processedTarget.preRecalFile, processedTarget.recalBam, asIntermediate = false))
+        if (!this.gatkOptions.bqsrOnTheFly) {
+          qscript.add(recal(processedTarget.dedupedBam, processedTarget.preRecalFile, processedTarget.recalBam, asIntermediate = false))
+          // calculate recalibration covariates after recalibration
+          qscript.add(cov(processedTarget.recalBam, processedTarget.postRecalFile, defaultPlatform = ""))
+        }
+        else
+          // calculate recalibration covariates after recalibration on-the-fly
+          qscript.add(cov(processedTarget.dedupedBam, processedTarget.postRecalFile, defaultPlatform = "", Some(processedTarget.preRecalFile)))
 
         processedTarget
       }

--- a/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
+++ b/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
@@ -76,6 +76,11 @@ class GATKDataProcessingUtils(
         qscript.add(recal(processedTarget.dedupedBam.file, processedTarget.preRecalFile, processedTarget.recalBam.file, asIntermediate = intermediateStep || processedTarget.recalBam.isIntermediate))
         // calculate recalibration covariates after recalibration
         qscript.add(cov(processedTarget.recalBam.file, processedTarget.postRecalFile, defaultPlatform = "", asIntermediate = intermediateStep))
+        // unless this is an intermediate step, produce the covariates plot
+        // TODO: there are some R dependencies (ggplot2) which are not satisfied, so lets' disable this for now
+        //if (!intermediateStep) {
+        //  qscript.add(analyze(processedTarget.preRecalFile, processedTarget.postRecalFile, processedTarget.covariatesPlotFile, asIntermediate = false))
+        //}
 
         processedTarget
       }

--- a/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
+++ b/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
@@ -71,7 +71,7 @@ class GATKDataProcessingUtils(
         // calculate recalibration covariates
         qscript.add(cov(processedTarget.dedupedBam, processedTarget.preRecalFile, defaultPlatform = ""))
         // apply recalibration
-        qscript.add(recal(processedTarget.dedupedBam, processedTarget.preRecalFile, processedTarget.recalBam, asIntermediate = false))
+        qscript.add(recal(processedTarget.dedupedBam, processedTarget.preRecalFile, processedTarget.recalBam, asIntermediate = this.gatkOptions.keepPreBQSRBam))
         // calculate recalibration covariates after recalibration
         qscript.add(cov(processedTarget.recalBam, processedTarget.postRecalFile, defaultPlatform = ""))
 

--- a/src/main/scala/molmed/utils/GATKProcessingTarget.scala
+++ b/src/main/scala/molmed/utils/GATKProcessingTarget.scala
@@ -9,14 +9,13 @@ import org.broadinstitute.gatk.tools.walkers.indels.IndelRealigner.ConsensusDete
 class GATKProcessingTarget(outputDir: File,
                            val bam: File,
                            val skipDeduplication: Boolean,
-                           val bqsrOnTheFly: Boolean,
                            val globalIntervals: Option[File]) {
 
     // Processed bam files
     val cleanedBam = GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam")
     val dedupedBam = if (!skipDeduplication) GeneralUtils.swapExt(outputDir, cleanedBam, ".bam", ".dedup.bam") else cleanedBam
     val recalBam = GeneralUtils.swapExt(outputDir, dedupedBam, ".bam", ".recal.bam")
-    val processedBam = if (!bqsrOnTheFly) recalBam else dedupedBam
+    val processedBam = recalBam
 
     // Accessory files
     val targetIntervals = globalIntervals.getOrElse(GeneralUtils.swapExt(outputDir, bam, ".bam", ".intervals"))

--- a/src/main/scala/molmed/utils/GATKProcessingTarget.scala
+++ b/src/main/scala/molmed/utils/GATKProcessingTarget.scala
@@ -3,19 +3,33 @@ package molmed.utils
 import java.io.File
 import org.broadinstitute.gatk.tools.walkers.indels.IndelRealigner.ConsensusDeterminationModel
 
+case class GATKOutputFile(file: File,
+                          isIntermediate: Boolean)
+
 /**
  * Help class handling each GATK processing target. Storing input files, creating output filenames etc.
  */
 class GATKProcessingTarget(outputDir: File,
                            val bam: File,
                            val skipDeduplication: Boolean,
+                           val keepPreBQSRBam: Boolean,
                            val globalIntervals: Option[File]) {
 
     // Processed bam files
-    val cleanedBam = GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam")
-    val dedupedBam = if (!skipDeduplication) GeneralUtils.swapExt(outputDir, cleanedBam, ".bam", ".dedup.bam") else cleanedBam
-    val recalBam = GeneralUtils.swapExt(outputDir, dedupedBam, ".bam", ".recal.bam")
-    val processedBam = recalBam
+    val cleanedBam = new GATKOutputFile(
+      GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam"),
+      !(keepPreBQSRBam && skipDeduplication))
+    val dedupedBam =
+      if (!skipDeduplication)
+        new GATKOutputFile(GeneralUtils.swapExt(outputDir, cleanedBam.file, ".bam", ".dedup.bam"), !keepPreBQSRBam)
+      else
+        cleanedBam
+    val recalBam = new GATKOutputFile(
+      GeneralUtils.swapExt(outputDir, dedupedBam.file, ".bam", ".recal.bam"),
+      keepPreBQSRBam)
+
+    // the preBQSR or postBQSR BAM as the final product
+    def processedBam: GATKOutputFile = if (keepPreBQSRBam) dedupedBam else recalBam
 
     // Accessory files
     val targetIntervals = globalIntervals.getOrElse(GeneralUtils.swapExt(outputDir, bam, ".bam", ".intervals"))

--- a/src/main/scala/molmed/utils/GATKProcessingTarget.scala
+++ b/src/main/scala/molmed/utils/GATKProcessingTarget.scala
@@ -36,6 +36,7 @@ class GATKProcessingTarget(outputDir: File,
     val metricsFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".metrics")
     val preRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre_recal.table")
     val postRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post_recal.table")
+    val covariatesPlotFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".bqsr.covariates.pdf")
     val preOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre")
     val postOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post")
     val preValidateLog = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre.validation")

--- a/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/src/main/scala/molmed/utils/GATKUtils.scala
@@ -3,6 +3,7 @@ package molmed.utils
 import java.io.File
 
 import org.broadinstitute.gatk.tools.walkers.indels.IndelRealigner.ConsensusDeterminationModel
+import org.broadinstitute.gatk.queue.extensions.gatk.AnalyzeCovariates
 import org.broadinstitute.gatk.queue.extensions.gatk.BaseRecalibrator
 import org.broadinstitute.gatk.queue.extensions.gatk.CommandLineGATK
 import org.broadinstitute.gatk.queue.extensions.gatk.IndelRealigner
@@ -88,6 +89,17 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
     if (!inRecalFile.isEmpty)
       this.BQSR = inRecalFile.get
     override def jobRunnerJobName = projectName.get + "_cov"
+
+  }
+
+  case class analyze(preRecalFile: File, postRecalFile: File, covariatesPlotFile: File, asIntermediate: Boolean = false) extends AnalyzeCovariates with CommandLineGATKArgs with TwoCoreJob {
+
+    this.beforeReportFile = preRecalFile
+    this.afterReportFile = postRecalFile
+    this.plotsReportFile = covariatesPlotFile
+    this.isIntermediate = asIntermediate
+    this.scatterCount = gatkOptions.scatterGatherCount.get
+    override def jobRunnerJobName = projectName.get + "_analyze_covariates"
 
   }
 

--- a/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/src/main/scala/molmed/utils/GATKUtils.scala
@@ -70,9 +70,9 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
 
   }
 
-  case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String, inRecalFile: Option[File] = None) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
+  case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String, inRecalFile: Option[File] = None, asIntermediate: Boolean = false) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
 
-    this.isIntermediate = false
+    this.isIntermediate = asIntermediate
     this.num_cpu_threads_per_data_thread = gatkOptions.nbrOfThreads
 
     if (!gatkOptions.dbSNP.isEmpty)

--- a/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/src/main/scala/molmed/utils/GATKUtils.scala
@@ -99,6 +99,10 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
     this.bam_compression = Some(5)
 
     this.BQSR = inRecalFile
+    // Disable the insertion and deletion qualities (BI and BD tags)
+    this.disable_indel_quals = true
+    // Emit the original qualities (OQ tag)
+    this.emit_original_quals = true
     this.baq = CalculationMode.CALCULATE_AS_NECESSARY
     this.out = outBam
     this.scatterCount = gatkOptions.scatterGatherCount.get

--- a/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/src/main/scala/molmed/utils/GATKUtils.scala
@@ -72,6 +72,7 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
 
   case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String, inRecalFile: Option[File] = None) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
 
+    this.isIntermediate = false
     this.num_cpu_threads_per_data_thread = gatkOptions.nbrOfThreads
 
     if (!gatkOptions.dbSNP.isEmpty)
@@ -100,9 +101,9 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
 
     this.BQSR = inRecalFile
     // Disable the insertion and deletion qualities (BI and BD tags)
-    this.disable_indel_quals = true
+    this.disable_indel_quals = gatkOptions.disableIndelQuals
     // Emit the original qualities (OQ tag)
-    this.emit_original_quals = true
+    this.emit_original_quals = gatkOptions.emitOriginalQuals
     this.baq = CalculationMode.CALCULATE_AS_NECESSARY
     this.out = outBam
     this.scatterCount = gatkOptions.scatterGatherCount.get

--- a/src/main/scala/molmed/utils/GeneralUtils.scala
+++ b/src/main/scala/molmed/utils/GeneralUtils.scala
@@ -286,7 +286,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     @Argument pathToQualimap: File,
     @Argument isHuman: Boolean,
     @Argument(required = false) intervalFile: Option[File] = None)
-      extends FourCoreJob {
+      extends SixteenCoreJob {
 
     this.isIntermediate = false
     override def jobRunnerJobName = projectName.get + "_qualimap"

--- a/src/main/scala/molmed/utils/GeneralUtils.scala
+++ b/src/main/scala/molmed/utils/GeneralUtils.scala
@@ -270,7 +270,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     @Argument pathToQualimap: File,
     @Argument isHuman: Boolean,
     @Argument(required = false) intervalFile: Option[File] = None)
-      extends EightCoreJob {
+      extends SixteenCoreJob {
 
     this.isIntermediate = false
     override def jobRunnerJobName = projectName.get + "_qualimap"
@@ -289,14 +289,14 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     override def commandLine =
       pathToQualimap + " " +
-        " --java-mem-size=20G " +
+        " --java-mem-size=" + this.memoryLimit.getOrElse(64.0).toInt.toString + "G " +
         " bamqc " +
         " -bam " + bam.getAbsolutePath() +
         gffString +
         " --paint-chromosome-limits " +
         " " + compareGCString + " " +
         " -outdir " + outputBase.getAbsolutePath() + "/" +
-        " -nt 8" +
+        " -nt " + this.coreLimit.toInt.toString +
         " &> " + logFile.getAbsolutePath()
 
   }

--- a/src/main/scala/molmed/utils/GeneralUtils.scala
+++ b/src/main/scala/molmed/utils/GeneralUtils.scala
@@ -26,6 +26,7 @@ import molmed.queue.extensions.picard.BuildBamIndex
 import molmed.queue.extensions.picard.CollectTargetedPcrMetrics
 import molmed.queue.extensions.picard.FixMateInformation
 import molmed.queue.extensions.picard.MarkDuplicates
+import molmed.queue.extensions.picard.MarkDuplicatesMetrics
 import molmed.queue.setup.ReadPairContainer
 import molmed.queue.setup.Sample
 import molmed.queue.setup.SampleAPI
@@ -69,7 +70,11 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
       @Argument region: String, 
       @Argument asIntermediate: Boolean,
       @Argument samtoolsPath: String) extends SamtoolsBase(samtoolsPath) with OneCoreJob {
-    def commandLine = 
+
+    @Output
+    var outputBamIndex: File = GeneralUtils.swapExt(outputBam.getParentFile(), outputBam, ".bam", ".bam.bai")
+
+    def commandLine =
       samtoolsPath + " view -b " + bam + " " + region + " > " + outputBam + "; " +
       samtoolsPath + " index " + outputBam
     override def jobRunnerJobName = projectName.get + "_samtools_get_region"
@@ -79,7 +84,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
   /**
    * Joins the bam file specified to a single bam file.
    */
-  case class joinBams(@Input inBams: Seq[File], @Output outBam: File, asIntermediate: Boolean = false) extends MergeSamFiles with TwoCoreJob {
+  case class joinBams(inBams: Seq[File], outBam: File, asIntermediate: Boolean = false) extends MergeSamFiles with TwoCoreJob {
 
     this.isIntermediate = asIntermediate
 
@@ -92,7 +97,6 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     override def jobRunnerJobName = projectName.get + "_joinBams"
 
-    this.isIntermediate = false
   }
 
   /**
@@ -175,6 +179,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     this.input :+= inBam
     this.output = outBam
+    this.outputIndex = GeneralUtils.swapExt(outBam.getParentFile, outBam, ".bam", ".bai")
     this.metrics = metricsFile
 
     // 5 seems to be a good compromise between speed and file size
@@ -184,6 +189,17 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     // not die from overflowing the memory limit.
     this.memoryLimit = Some(14)
     override def jobRunnerJobName = projectName.get + "_dedup"
+  }
+
+  case class dedupMetrics(inBam: File, metricsFile: File) extends MarkDuplicatesMetrics with TwoCoreJob {
+
+    this.isIntermediate = false
+    this.input = Seq(inBam)
+    this.metrics = metricsFile
+    // Since we're discarding the ouptut, set the compression level to be low
+    this.compressionLevel = Some(1)
+    this.memoryLimit = Some(14)
+    override def jobRunnerJobName = projectName.get + "_dedup_metrics"
   }
 
   /**
@@ -270,7 +286,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     @Argument pathToQualimap: File,
     @Argument isHuman: Boolean,
     @Argument(required = false) intervalFile: Option[File] = None)
-      extends SixteenCoreJob {
+      extends FourCoreJob {
 
     this.isIntermediate = false
     override def jobRunnerJobName = projectName.get + "_qualimap"
@@ -289,7 +305,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     override def commandLine =
       pathToQualimap + " " +
-        " --java-mem-size=" + this.memoryLimit.getOrElse(64.0).toInt.toString + "G " +
+        " --java-mem-size=" + this.memoryLimit.get.toInt.toString + "G " +
         " bamqc " +
         " -bam " + bam.getAbsolutePath() +
         gffString +

--- a/src/main/scala/molmed/utils/MergeFilesUtils.scala
+++ b/src/main/scala/molmed/utils/MergeFilesUtils.scala
@@ -31,7 +31,12 @@ class MergeFilesUtils(qscript: QScript, projectName: Option[String], uppmaxConfi
           qscript.add(joinBams(files, mergedFile, asIntermediate))
           mergedFile
         } else {
-          qscript.add(createLink(files(0), mergedFile, new File(files(0) + ".bai"), new File(mergedFile + ".bai"), asIntermediate))
+          qscript.add(
+            createLink(files(0),
+              mergedFile,
+              new File(files(0) + ".bai"),
+              GeneralUtils.swapExt(outputDir, mergedFile, ".bam", ".bam.bai"),
+              asIntermediate))
           mergedFile
         }
       }

--- a/src/main/scala/molmed/utils/UppmaxJob.scala
+++ b/src/main/scala/molmed/utils/UppmaxJob.scala
@@ -19,42 +19,49 @@ class UppmaxJob(uppmaxConfig: UppmaxConfig) {
   def memLimit(memLimit: Option[Double]): Option[Double] = if (uppmaxConfig.testMode) Some(10) else memLimit
 
   trait OneCoreJob extends CommandLineFunction {
+    val coreLimit = 1
     this.jobNativeArgs = Seq("-p core -n 1") ++ projectBaseString
     this.memoryLimit = memLimit(Some(8))
     this.isIntermediate = false
   }
 
   trait TwoCoreJob extends CommandLineFunction {
+    val coreLimit = 2
     this.jobNativeArgs = Seq("-p core -n 2") ++ projectBaseString
     this.memoryLimit = memLimit(Some(16))
     this.isIntermediate = false
   }
 
   trait ThreeCoreJob extends CommandLineFunction {
+    val coreLimit = 3
     this.jobNativeArgs = Seq("-p core -n 3") ++ projectBaseString
     this.memoryLimit = memLimit(Some(24))
     this.isIntermediate = false
   }
 
   trait FourCoreJob extends CommandLineFunction {
+    val coreLimit = 4
     this.jobNativeArgs = Seq("-p core -n 4") ++ projectBaseString
     this.memoryLimit = memLimit(Some(32))
     this.isIntermediate = false
   }
 
   trait SixCoreJob extends CommandLineFunction {
+    val coreLimit = 6
     this.jobNativeArgs = Seq("-p core -n 6") ++ projectBaseString
     this.memoryLimit = memLimit(Some(48))
     this.isIntermediate = false
   }
 
   trait EightCoreJob extends CommandLineFunction {
+    val coreLimit = 8
     this.jobNativeArgs = Seq("-p core -n 8") ++ projectBaseString
     this.memoryLimit = memLimit(Some(64))
     this.isIntermediate = false
   }
 
   trait SixteenCoreJob extends CommandLineFunction {
+    val coreLimit = 16
     this.jobNativeArgs = Seq("-p node") ++ projectBaseString
     this.memoryLimit = memLimit(Some(128))
     this.isIntermediate = false

--- a/src/main/scala/molmed/utils/UppmaxJob.scala
+++ b/src/main/scala/molmed/utils/UppmaxJob.scala
@@ -60,10 +60,17 @@ class UppmaxJob(uppmaxConfig: UppmaxConfig) {
     this.isIntermediate = false
   }
 
+  trait TwelveCoreJob extends CommandLineFunction {
+    val coreLimit = 12
+    this.jobNativeArgs = Seq("-p core -n 12") ++ projectBaseString
+    this.memoryLimit = memLimit(Some(96))
+    this.isIntermediate = false
+  }
+
   trait SixteenCoreJob extends CommandLineFunction {
     val coreLimit = 16
     this.jobNativeArgs = Seq("-p node") ++ projectBaseString
-    this.memoryLimit = memLimit(Some(128))
+    this.memoryLimit = memLimit(Some(112))
     this.isIntermediate = false
   }
 

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -54,4 +54,5 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
                                 skipAnnotation: Boolean,
-                                skipVcfCompression: Boolean)
+                                skipVcfCompression: Boolean,
+                                bcftoolsPath: Option[File] = None)

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -247,7 +247,10 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
 
     val vcfExtension = targets(0).vcfExtension
     val unannotatedVariantFiles =
-      variantAndEvalFiles.filter(_.getName().endsWith(vcfExtension))
+      variantAndEvalFiles.filter(f =>
+        f.getName().endsWith(vcfExtension) &&
+          !f.getName().contains(".genomic.") &&
+          (config.noRecal || !f.getName().contains(".raw.")))
 
     if (config.skipAnnotation)
       variantAndEvalFiles

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -613,6 +613,8 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
 
     override def commandLine =
       config.snpEffPath.get.getAbsolutePath() + " " +
+        // Explicitly pass the JVM parameters to snpEff since it wraps the java command
+        " -Xmx" + this.memoryLimit.getOrElse(4.0).toInt.toString + "g " +
         " -c " + snpEffConfig + " " +
         " -csvStats " +
         " -stats " + output.getAbsolutePath() + ".snpEff.summary.csv " +

--- a/uppmax_global_config.xml
+++ b/uppmax_global_config.xml
@@ -51,6 +51,11 @@
             <path>/sw/apps/bioinfo/snpEff/4.1/nestor/scripts/snpEff</path>
 	    <version>4.1</version>
         </program>
+        <program>
+            <name>bcftools</name>
+            <path>/sw/apps/bioinfo/bcftools/1.2/nestor/bin/bcftools</path>
+            <version>1.2</version>
+        </program>
     </programs>
     <resources>
         <resource>


### PR DESCRIPTION
- Fixed calls to snpEff (RAM, skip intermediate files, compress output)
- Option to include/exclude OQ, BD and BI tags during bam recalibration
- Option to remove recalibrated bam from final output
- Fixes to processing BAMs when splitting using ParallelShell
- Fixes to handling intermediate files and some un-annotated output files (mostly index files)
 