### PR TITLE
Devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .classpath
 .project
 ~
+/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ scala:
    - "2.9.2"
 jdk:
    - oraclejdk7
-   - openjdk7
 before_install: export SBT_OPTS="-Xms1536m -Xmx1536m -XX:MaxPermSize=384m -XX:ReservedCodeCacheSize=192m"
 install: ./setup.sh
 script: sbt/bin/sbt test 

--- a/globalConfig.xml
+++ b/globalConfig.xml
@@ -49,7 +49,12 @@
         <program>
             <name>snpEff</name>
             <path>/data/programs/snpEff/snpEff</path>
-	    <version>4.0</version>
+            <version>4.0</version>
+        </program>
+        <program>
+            <name>bcftools</name>
+            <path>/data/programs/bcftools/bcftools</path>
+            <version>1.2</version>
         </program>
     </programs>
     <resources>

--- a/src/main/scala/molmed/config/Constants.scala
+++ b/src/main/scala/molmed/config/Constants.scala
@@ -19,6 +19,7 @@ object Constants {
   val CUTADAPT = "cutadapt"
   val TOPHAP = "tophat"
   val SNP_EFF = "snpEff"
+  val BCFTOOLS = "bcftools"
 
   val DB_SNP = "dbsnp"
   val INDELS = "indels"

--- a/src/main/scala/molmed/config/FileAndProgramResourceConfig.scala
+++ b/src/main/scala/molmed/config/FileAndProgramResourceConfig.scala
@@ -78,6 +78,9 @@ trait FileAndProgramResourceConfig {
   @Input(doc = "The path to the start-up script of snpEff", fullName = "path_to_snpeff", shortName = "snpEff", required = false)
   var snpEffPath: File = _
 
+  @Input(doc = "The path to the binary of bcftools", fullName = "path_to_bcftools", shortName = "bcftools", required = false)
+  var bcftoolsPath: File = _
+
   // Please not that this has no override in the xml file, but has to be overriden from the commandline if this is necessary.
   @Argument(doc = "The path to snpEff config", fullName = "path_to_snpeff_config", shortName = "snpEffConf", required = false)
   var snpEffConfigPath: File = _
@@ -262,6 +265,9 @@ trait FileAndProgramResourceConfig {
 
       if (this.snpEffPath == null)
         this.snpEffPath = getFileFromKey(programNameToPathsMap, Constants.SNP_EFF)
+
+      if (this.bcftoolsPath == null)
+        this.bcftoolsPath = getFileFromKey(programNameToPathsMap, Constants.BCFTOOLS)
 
       programNameToPathsMap
 

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -10,6 +10,7 @@ import molmed.utils.BwaMem
 import molmed.utils.GATKConfig
 import molmed.utils.GATKDataProcessingUtils
 import molmed.utils.GATKHaplotypeCaller
+import molmed.utils.GATKProcessingTarget
 import molmed.utils.GATKUnifiedGenotyper
 import molmed.utils.GeneralUtils
 import molmed.utils.MergeFilesUtils
@@ -101,6 +102,9 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(fullName = "skip_annotation", shortName = "noAnnotation", doc = "Skip the snpEff annotation step", required = false)
   var skipAnnotation: Boolean = false
 
+  @Argument(fullName = "skip_vcf_compression", shortName = "noCompress", doc = "Skip gz compression of vcf files", required = false)
+  var skipVcfCompression: Boolean = false
+
   @Argument(shortName = "mbq", doc = "The minimum Phred-Scaled quality score threshold to be considered a good base in variant calling", required = false)
   var minimumBaseQuality: Int = -1
 
@@ -136,6 +140,9 @@ class DNABestPracticeVariantCalling extends QScript
 
   @Argument(doc = "When using the --super_charge option, use this to specify number of groups (default: 3)", fullName = "ways_to_split", shortName = "wts", required = false)
   var groupsToSplitTo: Int = 3
+
+  @Argument(doc = "Do Base Quality Score Recalibration (BQSR) on-the-fly during variant calling, rather than creating base-recalibrated bam files (default)", fullName = "bqsr_otf", shortName = "botf", required = false)
+  var bqsrOnTheFly: Boolean = false
 
   /**
    * **************************************************************************
@@ -233,7 +240,7 @@ class DNABestPracticeVariantCalling extends QScript
 
     if (snpGenotypes.isDefined) {
       qualityControlUtils.checkGenotypeConcordance(
-        bams = bamFiles,
+        bamFiles = bamFiles,
         outputBase = genotypeConcordanceOutputDir,
         comparisonVcf = snpGenotypes.get,
         qscript = this,
@@ -243,7 +250,8 @@ class DNABestPracticeVariantCalling extends QScript
         isLowPass = this.isLowPass,
         isExome = this.isExome,
         testMode = this.testMode,
-        minimumBaseQuality = this.minimumBaseQuality)
+        minimumBaseQuality = this.minimumBaseQuality,
+        skipVcfCompression = this.skipVcfCompression)
     }
 
     /**
@@ -301,12 +309,12 @@ class DNABestPracticeVariantCalling extends QScript
     gatkOptions: GATKConfig,
     generalUtils: GeneralUtils,
     uppmaxConfig: UppmaxConfig,
-    reference: File): Seq[File] = {
+    reference: File): Seq[GATKProcessingTarget] = {
 
     /**
      * Used internally to handle splitting, processing and merging.
      */
-    def runDataProcessingOnSplitByChromosomeAndMerge = {
+    def runDataProcessingOnSplitByChromosomeAndMerge: Seq[GATKProcessingTarget] = {
 
       val updateGATKOptions = gatkOptions.copy(nbrOfThreads = 16 / groupsToSplitTo)
       
@@ -315,31 +323,37 @@ class DNABestPracticeVariantCalling extends QScript
 
       val splitsBams = runChromosomeSplitting(bams, groupsToSplitTo, generalUtils, reference)
 
-      val splitAndProcessedBams =
+      val splitAndProcessedBamTargets =
         for (splitGroup <- splitsBams) yield {
-          val processedBamFiles = gatkDataProcessingUtils.dataProcessing(
+          val processedBamTargets = gatkDataProcessingUtils.dataProcessing(
             splitGroup, processedAligmentsOutputDir, cleaningModel,
             skipDeduplication = false, testMode)
-          processedBamFiles
+          processedBamTargets
         }
 
-      for (toMergeBams <- splitAndProcessedBams) yield {
+      for (toMergeBamTarget <- splitAndProcessedBamTargets) yield {
 
         // Assumes that the start of the file name is the same, and is what is to
         // be used name these files.
-        val nameOfOutputBam =
-          if (toMergeBams.size > 1) {
-            val firstFileName = toMergeBams(0).getName()
-            val secondFileName = toMergeBams(1).getName()
-            val longestCommonName =
-              firstFileName.zip(secondFileName).takeWhile(Function.tupled(_ == _)).map(_._1).mkString
-            // The splitting will add a _, removing it here.  
-            longestCommonName.stripSuffix("_")
-          } else
-            toMergeBams(0).getName().stripSuffix(".bam")
+        
+        def _longestCommonPrefix(fileNames: Seq[String]): String = {
+          if (fileNames.size > 1)
+              fileNames(0).zip(fileNames(1)).takeWhile(Function.tupled(_ == _)).map(_._1).mkString.stripSuffix("_")
+          else
+              fileNames(0).stripSuffix(".bam")
+        }
+        val nameOfOriginalBam = _longestCommonPrefix( toMergeBamTarget.map( _.bam.getName() ))
+        val mergedBamTarget = new GATKProcessingTarget(
+            processedAligmentsOutputDir, 
+            new File(processedAligmentsOutputDir + "/" + nameOfOriginalBam + ".bam"),
+            toMergeBamTarget(0).skipDeduplication,
+            toMergeBamTarget(0).bqsrOnTheFly,
+            toMergeBamTarget(0).globalIntervals)
+        SplitFilesAndMergeByChromosome.merge(qscript, toMergeBamTarget.map( _.processedBam ), mergedBamTarget.processedBam, asIntermediate = false, generalUtils)
+        SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.preRecalFile ), mergedBamTarget.preRecalFile, asIntermediate = false, generalUtils)
+        SplitFilesAndMergeByChromosome.mergeRecalibrationTables(qscript, toMergeBamTarget.map( _.postRecalFile ), mergedBamTarget.postRecalFile, asIntermediate = false, generalUtils)
 
-        val outBam = new File(processedAligmentsOutputDir + "/" + nameOfOutputBam + ".bam")
-        SplitFilesAndMergeByChromosome.merge(qscript, toMergeBams, outBam, asIntermediate = false, generalUtils)
+        mergedBamTarget
       }
     }
 
@@ -361,7 +375,7 @@ class DNABestPracticeVariantCalling extends QScript
    * Variant calling
    */
   def runVariantCalling(
-    bamFiles: Seq[File],
+    bamTargets: Seq[GATKProcessingTarget],
     outputDirectory: File,
     gatkOptions: GATKConfig,
     uppmaxConfig: UppmaxConfig): Seq[File] = {
@@ -378,7 +392,7 @@ class DNABestPracticeVariantCalling extends QScript
     val variantCallingConfig = new VariantCallingConfig(
       qscript = this,
       variantCaller = variantCallerToUse,
-      bamFiles,
+      bamTargets,
       outputDirectory,
       runSeparatly,
       isLowPass,
@@ -394,7 +408,8 @@ class DNABestPracticeVariantCalling extends QScript
       snpEffPath,
       snpEffConfigPath,
       Some(snpEffReference),
-      skipAnnotation)
+      skipAnnotation,
+      skipVcfCompression)
 
     variantCallingUtils.performVariantCalling(variantCallingConfig)
   }
@@ -493,7 +508,7 @@ class DNABestPracticeVariantCalling extends QScript
       new GATKConfig(reference, nbrOfThreads, scatterGatherCount,
         intervals,
         dbSNP, Some(indels), hapmap, omni, mills, thousandGenomes,
-        notHuman)
+        notHuman, bqsrOnTheFly = bqsrOnTheFly)
 
     // Drop the version report (this will be overwritten each time the 
     // qscript is run.
@@ -532,7 +547,7 @@ class DNABestPracticeVariantCalling extends QScript
         gatkOptions, generalUtils, uppmaxConfig, reference)
 
     val variantCalling = runVariantCalling(
-      _: Seq[File], variantCallsOutputDir,
+      _: Seq[GATKProcessingTarget], variantCallsOutputDir,
       gatkOptions, uppmaxConfig)
 
     /**
@@ -568,16 +583,16 @@ class DNABestPracticeVariantCalling extends QScript
         val aligments = alignments(samples)
         val qc = qualityControl(aligments.values.flatten.toSeq, preliminaryAlignmentQCOutputDir)
         val mergedBams = mergedAlignments(aligments)
-        val processedBams = dataProcessing(mergedBams)
-        qualityControl(processedBams, finalAlignmentQCOutputDir)
+        val processedBamTargets = dataProcessing(mergedBams)
+        qualityControl(processedBamTargets.map( _.processedBam ), finalAlignmentQCOutputDir)
       }
       case e if e.contains(AnalysisSteps.VariantCalling) => {
         val aligments = alignments(samples)
         val qc = qualityControl(aligments.values.flatten.toSeq, preliminaryAlignmentQCOutputDir)
         val mergedBams = mergedAlignments(aligments)
-        val processedBams = dataProcessing(mergedBams)
-        qualityControl(processedBams, finalAlignmentQCOutputDir)
-        variantCalling(processedBams)
+        val processedBamTargets = dataProcessing(mergedBams)
+        qualityControl(processedBamTargets.map( _.processedBam ), finalAlignmentQCOutputDir)
+        variantCalling(processedBamTargets)
       }
       case e if e.contains(AnalysisSteps.GenerateDelivery) => {
 
@@ -589,13 +604,13 @@ class DNABestPracticeVariantCalling extends QScript
         val aligments = alignments(samples)
         val preliminaryQC = qualityControl(aligments.values.flatten.toSeq, preliminaryAlignmentQCOutputDir)
         val mergedBams = mergedAlignments(aligments)
-        val processedBams = dataProcessing(mergedBams)
-        val finalQC = qualityControl(processedBams, finalAlignmentQCOutputDir)
-        val variantCallFiles = variantCalling(processedBams)
+        val processedBamTargets = dataProcessing(mergedBams)
+        val finalQC = qualityControl(processedBamTargets.map( _.processedBam ), finalAlignmentQCOutputDir)
+        val variantCallFiles = variantCalling(processedBamTargets)
 
         runCreateDelivery(
           fastqs,
-          processedBams,
+          processedBamTargets.map( _.processedBam ),
           finalQC,
           variantCallFiles,
           reportFile,

--- a/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
@@ -122,7 +122,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
 
     val intervalOption = if(intervals == null) None else Some(intervals) 
     
-    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, bqsrOnTheFly = false, intervalOption) )
+    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, gatkOptions.keepPreBQSRBam, intervalOption) )
     
     val targets = (runSeparatly, notHuman) match {
       case (true, false) => bamTargets.map(bamTarget => new VariantCallingTarget(outputDir, bamTarget.bam.getName(), reference, Seq(bamTarget), intervalOption, isLowpass, isExome, 1))
@@ -135,7 +135,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
       if (!skipCalling) {
         if (!noIndels) {
           // Indel calling, recalibration and evaulation
-          add(new variantCallingUtils.UnifiedGenotyperIndelCall(target, testMode, downsampleFraction, Some(false)))
+          add(new variantCallingUtils.UnifiedGenotyperIndelCall(target, testMode, downsampleFraction))
           if (!noRecal) {
             add(new variantCallingUtils.IndelRecalibration(target))
             add(new variantCallingUtils.IndelCut(target))
@@ -143,7 +143,7 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
           }
         }
         // SNP calling, recalibration and evaluation
-        add(new variantCallingUtils.UnifiedGenotyperSnpCall(target, testMode, downsampleFraction, minimumBaseQuality, deletions, noBAQ, Some(false)))
+        add(new variantCallingUtils.UnifiedGenotyperSnpCall(target, testMode, downsampleFraction, minimumBaseQuality, deletions, noBAQ))
         if (!noRecal) {
           add(new variantCallingUtils.SnpRecalibration(target))
           add(new variantCallingUtils.SnpCut(target))

--- a/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
+++ b/src/main/scala/molmed/queue/extensions/picard/MarkDuplicates.scala
@@ -30,27 +30,23 @@ import java.io.File
 import org.broadinstitute.gatk.queue.extensions.picard.PicardBamFunction
 import org.broadinstitute.gatk.queue.function.JavaCommandLineFunction
 
+import molmed.utils.GeneralUtils
+
+
 /**
  * This MarkDuplicates extention is identical to the one provided with GATK
- * Queue with the exception that the metrics file is not annotated as a output,
- * but rather as an argument. This means it will not be removed if there the
- * class is added as an intermediate step in your pipeline.
+ * Queue with the exception that the annotations for the output, outputIndex and
+ * metrics files are left to subclasses extending this wrapper.
  */
-class MarkDuplicates extends JavaCommandLineFunction with PicardBamFunction {
+trait MarkDuplicatesWrapper extends JavaCommandLineFunction with PicardBamFunction {
   analysisName = "MarkDuplicates"
   javaMainClass = "picard.sam.MarkDuplicates"
 
+  var output: File
+  var metrics: File
+
   @Input(doc="The input SAM or BAM files to analyze.  Must be coordinate sorted.", shortName = "input", fullName = "input_bam_files", required = true)
   var input: Seq[File] = Nil
-
-  @Output(doc="The output file to write marked records to", shortName = "output", fullName = "output_bam_file", required = true)
-  var output: File = _
-
-  @Output(doc="The output bam index", shortName = "out_index", fullName = "output_bam_index_file", required = false)
-  var outputIndex: File = _
-
-  @Argument(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
-  var metrics: File = new File(output + ".metrics")
 
   @Argument(doc="If true do not write duplicates to the output file instead of writing them with appropriate flags set.", shortName = "remdup", fullName = "remove_duplicates", required = false)
   var REMOVE_DUPLICATES: Boolean = false
@@ -61,20 +57,52 @@ class MarkDuplicates extends JavaCommandLineFunction with PicardBamFunction {
   @Argument(doc = "This number, plus the maximum RAM available to the JVM, determine the memory footprint used by some of the sorting collections.  If you are running out of memory, try reducing this number.", shortName = "sorting_ratio", fullName = "sorting_collection_size_ratio", required = false)
   var SORTING_COLLECTION_SIZE_RATIO: Double = -1
 
-  override def freezeFieldValues() {
-    super.freezeFieldValues()
-    if (outputIndex == null && output != null)
-      outputIndex = new File(output.getName.stripSuffix(".bam") + ".bai")
-  }
-
-
   override def inputBams = input
   override def outputBam = output
   this.sortOrder = null
   this.createIndex = Some(true)
   override def commandLine = super.commandLine +
-                             required("M=" + metrics) +
-                             conditional(REMOVE_DUPLICATES, "REMOVE_DUPLICATES=true") +
-                             conditional(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP > 0, "MAX_FILE_HANDLES_FOR_READ_ENDS_MAP=" + MAX_FILE_HANDLES_FOR_READ_ENDS_MAP.toString) +
-                             conditional(SORTING_COLLECTION_SIZE_RATIO > 0, "SORTING_COLLECTION_SIZE_RATIO=" + SORTING_COLLECTION_SIZE_RATIO.toString)
+    required("M=" + metrics) +
+    conditional(REMOVE_DUPLICATES, "REMOVE_DUPLICATES=true") +
+    conditional(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP > 0, "MAX_FILE_HANDLES_FOR_READ_ENDS_MAP=" + MAX_FILE_HANDLES_FOR_READ_ENDS_MAP.toString) +
+    conditional(SORTING_COLLECTION_SIZE_RATIO > 0, "SORTING_COLLECTION_SIZE_RATIO=" + SORTING_COLLECTION_SIZE_RATIO.toString)
+}
+
+/**
+ * This MarkDuplicates extention extends the wrapper above and annotates the metrics file as an argument
+ * instead of as an output. This means it will not be removed if there the
+ * class is added as an intermediate step in your pipeline. Otherwise, the functionality is identical
+ * to the MarkDuplicates extension supplied with GATK.
+ */
+class MarkDuplicates extends MarkDuplicatesWrapper {
+
+  @Output(doc="The output file to write marked records to", shortName = "output", fullName = "output_bam_file", required = true)
+  var output: File = _
+
+  @Output(doc="The output bam index", shortName = "out_index", fullName = "output_bam_index_file", required = false)
+  var outputIndex: File = _
+
+  @Argument(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
+  var metrics: File = new File(output + ".metrics")
+
+  override def freezeFieldValues() {
+    super.freezeFieldValues()
+    if (outputIndex == null && output != null)
+      outputIndex = new File(output.getName.stripSuffix(".bam") + ".bai")
+  }
+}
+
+/**
+ * This MarkDuplicates extention extends the wrapper above and discards the output and outputIndex,
+ * just generating and keeping the metrics file (as an output). NB: this behaviour is Unix-specific.
+ */
+class MarkDuplicatesMetrics extends MarkDuplicatesWrapper {
+
+  var output: File = new File("/dev/null")
+
+  @Output(doc="File to write duplication metrics to", shortName = "out_metrics", fullName = "output_metrics_file", required = true)
+  var metrics: File = _
+
+  this.createIndex = Some(false)
+
 }

--- a/src/main/scala/molmed/report/ReportGenerator.scala
+++ b/src/main/scala/molmed/report/ReportGenerator.scala
@@ -124,7 +124,7 @@ object ReportGenerator {
 README
 ******
       
-Data has been mapped to the reference using Tophat. Transcripts were quantified using cufflinks, and quality control data was collected using Cufflinks. The pipeline system used was Piper (see below for more information).      
+Data has been mapped to the reference using Tophat. Transcripts were quantified using cufflinks, and quality control data was collected using RNA-SeQC. The pipeline system used was Piper (see below for more information).      
 
 The versions of programs and references used:
 piper: $piperVersion

--- a/src/main/scala/molmed/report/ReportGenerator.scala
+++ b/src/main/scala/molmed/report/ReportGenerator.scala
@@ -165,7 +165,7 @@ Piper is a pipeline system developed and maintained at the National Genomics Inf
     val qualimapVersion = fileVersionFromKey(resourceMap, Constants.QUALIMAP)
     val gatkVersion = getGATKVersion()
     val snpEffVersion = fileVersionFromKey(resourceMap, Constants.SNP_EFF)
-
+    val snpEffReference = fileVersionFromKey(resourceMap, Constants.SNP_EFF_REFERENCE)
     val referenceName = reference.getName()
     val dbSNPVersion = fileVersionFromKey(resourceMap, Constants.DB_SNP)
     val thousandGenomesIndelsVersion = fileVersionFromKey(resourceMap, Constants.THOUSAND_GENOMES)
@@ -192,6 +192,7 @@ bwa: $bwaVersion
 samtools: $samtoolsVersion
 qualimap: $qualimapVersion
 snpEff: $snpEffVersion
+snpEff reference: $snpEffReference
 gatk: $gatkVersion
 
 reference: $referenceName

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -75,7 +75,7 @@ class AlignmentQCUtils(
           bamFile.getParentFile(),
           bamFile,
           skipDeduplication = false,
-          gatkOptions.bqsrOnTheFly,
+          keepPreBQSRBam = false,
           gatkOptions.intervalFile) )
     val variantCallingUtils = new VariantCallingUtils(gatkOptionsWithGenotypingSnp, projectName, uppmaxConfig)
     val variantCallingConfig = new VariantCallingConfig(

--- a/src/main/scala/molmed/utils/AlignmentUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentUtils.scala
@@ -276,6 +276,8 @@ class BwaAlignmentUtils(qscript: QScript, bwaPath: String, bwaThreads: Int, samt
     @Input(doc = "fastq file with mate 2 file to be aligned") var mate2 = fastq2
     @Input(doc = "reference") var ref = reference
     @Output(doc = "output aligned bam file") var alignedBam = outBam
+    @Output(doc = "output aligned bam index file") var bamIndex = GeneralUtils.swapExt(
+      outBam.getParentFile, outBam, ".bam", ".bam.bai")
 
     // The output from this is a samfile, which can be removed later
     this.isIntermediate = intermediate

--- a/src/main/scala/molmed/utils/GATKConfig.scala
+++ b/src/main/scala/molmed/utils/GATKConfig.scala
@@ -17,4 +17,5 @@ case class GATKConfig(
   mills: Option[File] = None,
   thousandGenomes: Option[File] = None,
   notHuman: Boolean = false,
-  snpGenotypingVcf: Option[File] = None)
+  snpGenotypingVcf: Option[File] = None,
+  bqsrOnTheFly: Boolean = false)

--- a/src/main/scala/molmed/utils/GATKConfig.scala
+++ b/src/main/scala/molmed/utils/GATKConfig.scala
@@ -18,4 +18,6 @@ case class GATKConfig(
   thousandGenomes: Option[File] = None,
   notHuman: Boolean = false,
   snpGenotypingVcf: Option[File] = None,
-  bqsrOnTheFly: Boolean = false)
+  keepPreBQSRBam: Boolean = false,
+  disableIndelQuals: Boolean = false,
+  emitOriginalQuals: Boolean = false)

--- a/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
+++ b/src/main/scala/molmed/utils/GATKDataProcessingUtils.scala
@@ -31,7 +31,8 @@ class GATKDataProcessingUtils(
                      outputDir: File,
                      cleaningModel: String,
                      skipDeduplication: Boolean = false,
-                     testMode: Boolean): Seq[GATKProcessingTarget] = {
+                     testMode: Boolean,
+                     intermediateStep: Boolean): Seq[GATKProcessingTarget] = {
 
     def getIndelCleaningModel: ConsensusDeterminationModel = {
       if (cleaningModel == "KNOWNS_ONLY")
@@ -58,24 +59,28 @@ class GATKDataProcessingUtils(
             outputDir,
             bam,
             skipDeduplication,
-            this.gatkOptions.bqsrOnTheFly,
+            this.gatkOptions.keepPreBQSRBam,
             if (cleaningModel == ConsensusDeterminationModel.KNOWNS_ONLY) Some(globalIntervals) else None)
 
         if (cleaningModel != ConsensusDeterminationModel.KNOWNS_ONLY)
           qscript.add(target(Seq(processedTarget.bam), processedTarget.targetIntervals, cleanModelEnum))
 
         // realign
-        qscript.add(clean(Seq(processedTarget.bam), processedTarget.targetIntervals, processedTarget.cleanedBam, cleanModelEnum, testMode))
+        qscript.add(clean(Seq(processedTarget.bam), processedTarget.targetIntervals, processedTarget.cleanedBam.file, cleanModelEnum, testMode, asIntermediate = intermediateStep || processedTarget.cleanedBam.isIntermediate))
         // mark duplicates unless we're told not to
         if (!skipDeduplication)
-            qscript.add(generalUtils.dedup(processedTarget.cleanedBam, processedTarget.dedupedBam, processedTarget.metricsFile, asIntermediate = !this.gatkOptions.bqsrOnTheFly))
+            qscript.add(generalUtils.dedup(processedTarget.cleanedBam.file, processedTarget.dedupedBam.file, processedTarget.metricsFile, asIntermediate = intermediateStep || processedTarget.dedupedBam.isIntermediate))
         // calculate recalibration covariates
-        qscript.add(cov(processedTarget.dedupedBam, processedTarget.preRecalFile, defaultPlatform = ""))
+        qscript.add(cov(processedTarget.dedupedBam.file, processedTarget.preRecalFile, defaultPlatform = "", asIntermediate = intermediateStep))
+        // apply recalibration
+        qscript.add(recal(processedTarget.dedupedBam.file, processedTarget.preRecalFile, processedTarget.recalBam.file, asIntermediate = intermediateStep || processedTarget.recalBam.isIntermediate))
         // calculate recalibration covariates after recalibration
-        qscript.add(cov(processedTarget.dedupedBam, processedTarget.postRecalFile, defaultPlatform = "", Some(processedTarget.preRecalFile)))
-        // apply recalibration unless we should do it on-the-fly
-        if (!this.gatkOptions.bqsrOnTheFly)
-            qscript.add(recal(processedTarget.dedupedBam, processedTarget.preRecalFile, processedTarget.recalBam, asIntermediate = false))
+        qscript.add(cov(processedTarget.recalBam.file, processedTarget.postRecalFile, defaultPlatform = "", asIntermediate = intermediateStep))
+        // unless this is an intermediate step, produce the covariates plot
+        // TODO: there are some R dependencies (ggplot2) which are not satisfied, so lets' disable this for now
+        //if (!intermediateStep) {
+        //  qscript.add(analyze(processedTarget.preRecalFile, processedTarget.postRecalFile, processedTarget.covariatesPlotFile, asIntermediate = false))
+        //}
 
         processedTarget
       }

--- a/src/main/scala/molmed/utils/GATKProcessingTarget.scala
+++ b/src/main/scala/molmed/utils/GATKProcessingTarget.scala
@@ -3,26 +3,40 @@ package molmed.utils
 import java.io.File
 import org.broadinstitute.gatk.tools.walkers.indels.IndelRealigner.ConsensusDeterminationModel
 
+case class GATKOutputFile(file: File,
+                          isIntermediate: Boolean)
+
 /**
  * Help class handling each GATK processing target. Storing input files, creating output filenames etc.
  */
 class GATKProcessingTarget(outputDir: File,
                            val bam: File,
                            val skipDeduplication: Boolean,
-                           val bqsrOnTheFly: Boolean,
+                           val keepPreBQSRBam: Boolean,
                            val globalIntervals: Option[File]) {
 
     // Processed bam files
-    val cleanedBam = GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam")
-    val dedupedBam = if (!skipDeduplication) GeneralUtils.swapExt(outputDir, cleanedBam, ".bam", ".dedup.bam") else cleanedBam
-    val recalBam = GeneralUtils.swapExt(outputDir, dedupedBam, ".bam", ".recal.bam")
-    val processedBam = if (!bqsrOnTheFly) recalBam else dedupedBam
+    val cleanedBam = new GATKOutputFile(
+      GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam"),
+      !(keepPreBQSRBam && skipDeduplication))
+    val dedupedBam =
+      if (!skipDeduplication)
+        new GATKOutputFile(GeneralUtils.swapExt(outputDir, cleanedBam.file, ".bam", ".dedup.bam"), !keepPreBQSRBam)
+      else
+        cleanedBam
+    val recalBam = new GATKOutputFile(
+      GeneralUtils.swapExt(outputDir, dedupedBam.file, ".bam", ".recal.bam"),
+      keepPreBQSRBam)
+
+    // the preBQSR or postBQSR BAM as the final product
+    def processedBam: GATKOutputFile = if (keepPreBQSRBam) dedupedBam else recalBam
 
     // Accessory files
     val targetIntervals = globalIntervals.getOrElse(GeneralUtils.swapExt(outputDir, bam, ".bam", ".intervals"))
     val metricsFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".metrics")
     val preRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre_recal.table")
     val postRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post_recal.table")
+    val covariatesPlotFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".bqsr.covariates.pdf")
     val preOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre")
     val postOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post")
     val preValidateLog = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre.validation")

--- a/src/main/scala/molmed/utils/GATKProcessingTarget.scala
+++ b/src/main/scala/molmed/utils/GATKProcessingTarget.scala
@@ -1,0 +1,31 @@
+package molmed.utils
+
+import java.io.File
+import org.broadinstitute.gatk.tools.walkers.indels.IndelRealigner.ConsensusDeterminationModel
+
+/**
+ * Help class handling each GATK processing target. Storing input files, creating output filenames etc.
+ */
+class GATKProcessingTarget(outputDir: File,
+                           val bam: File,
+                           val skipDeduplication: Boolean,
+                           val bqsrOnTheFly: Boolean,
+                           val globalIntervals: Option[File]) {
+
+    // Processed bam files
+    val cleanedBam = GeneralUtils.swapExt(outputDir, bam, ".bam", ".clean.bam")
+    val dedupedBam = if (!skipDeduplication) GeneralUtils.swapExt(outputDir, cleanedBam, ".bam", ".dedup.bam") else cleanedBam
+    val recalBam = GeneralUtils.swapExt(outputDir, dedupedBam, ".bam", ".recal.bam")
+    val processedBam = if (!bqsrOnTheFly) recalBam else dedupedBam
+
+    // Accessory files
+    val targetIntervals = globalIntervals.getOrElse(GeneralUtils.swapExt(outputDir, bam, ".bam", ".intervals"))
+    val metricsFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".metrics")
+    val preRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre_recal.table")
+    val postRecalFile = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post_recal.table")
+    val preOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre")
+    val postOutPath = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post")
+    val preValidateLog = GeneralUtils.swapExt(outputDir, bam, ".bam", ".pre.validation")
+    val postValidateLog = GeneralUtils.swapExt(outputDir, bam, ".bam", ".post.validation")
+
+}

--- a/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/src/main/scala/molmed/utils/GATKUtils.scala
@@ -70,7 +70,7 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
 
   }
 
-  case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
+  case class cov(inBam: File, outRecalFile: File, @Argument defaultPlatform: String, inRecalFile: Option[File] = None) extends BaseRecalibrator with CommandLineGATKArgs with EightCoreJob {
 
     this.num_cpu_threads_per_data_thread = gatkOptions.nbrOfThreads
 
@@ -84,6 +84,8 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
     if (!gatkOptions.intervalFile.isEmpty) this.intervals :+= gatkOptions.intervalFile.get
 
     this.scatterCount = gatkOptions.scatterGatherCount.get
+    if (!inRecalFile.isEmpty)
+      this.BQSR = inRecalFile.get
     override def jobRunnerJobName = projectName.get + "_cov"
 
   }
@@ -101,7 +103,6 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
     this.out = outBam
     this.scatterCount = gatkOptions.scatterGatherCount.get
     this.num_cpu_threads_per_data_thread = gatkOptions.nbrOfThreads
-    this.isIntermediate = false
     override def jobRunnerJobName = projectName.get + "_recal"
 
   }

--- a/src/main/scala/molmed/utils/GeneralUtils.scala
+++ b/src/main/scala/molmed/utils/GeneralUtils.scala
@@ -26,6 +26,7 @@ import molmed.queue.extensions.picard.BuildBamIndex
 import molmed.queue.extensions.picard.CollectTargetedPcrMetrics
 import molmed.queue.extensions.picard.FixMateInformation
 import molmed.queue.extensions.picard.MarkDuplicates
+import molmed.queue.extensions.picard.MarkDuplicatesMetrics
 import molmed.queue.setup.ReadPairContainer
 import molmed.queue.setup.Sample
 import molmed.queue.setup.SampleAPI
@@ -69,7 +70,11 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
       @Argument region: String, 
       @Argument asIntermediate: Boolean,
       @Argument samtoolsPath: String) extends SamtoolsBase(samtoolsPath) with OneCoreJob {
-    def commandLine = 
+
+    @Output
+    var outputBamIndex: File = GeneralUtils.swapExt(outputBam.getParentFile(), outputBam, ".bam", ".bam.bai")
+
+    def commandLine =
       samtoolsPath + " view -b " + bam + " " + region + " > " + outputBam + "; " +
       samtoolsPath + " index " + outputBam
     override def jobRunnerJobName = projectName.get + "_samtools_get_region"
@@ -79,7 +84,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
   /**
    * Joins the bam file specified to a single bam file.
    */
-  case class joinBams(@Input inBams: Seq[File], @Output outBam: File, asIntermediate: Boolean = false) extends MergeSamFiles with TwoCoreJob {
+  case class joinBams(inBams: Seq[File], outBam: File, asIntermediate: Boolean = false) extends MergeSamFiles with TwoCoreJob {
 
     this.isIntermediate = asIntermediate
 
@@ -92,7 +97,6 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     override def jobRunnerJobName = projectName.get + "_joinBams"
 
-    this.isIntermediate = false
   }
 
   /**
@@ -175,6 +179,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     this.input :+= inBam
     this.output = outBam
+    this.outputIndex = GeneralUtils.swapExt(outBam.getParentFile, outBam, ".bam", ".bai")
     this.metrics = metricsFile
 
     // 5 seems to be a good compromise between speed and file size
@@ -184,6 +189,17 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     // not die from overflowing the memory limit.
     this.memoryLimit = Some(14)
     override def jobRunnerJobName = projectName.get + "_dedup"
+  }
+
+  case class dedupMetrics(inBam: File, metricsFile: File) extends MarkDuplicatesMetrics with TwoCoreJob {
+
+    this.isIntermediate = false
+    this.input = Seq(inBam)
+    this.metrics = metricsFile
+    // Since we're discarding the ouptut, set the compression level to be low
+    this.compressionLevel = Some(1)
+    this.memoryLimit = Some(14)
+    override def jobRunnerJobName = projectName.get + "_dedup_metrics"
   }
 
   /**
@@ -270,7 +286,7 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     @Argument pathToQualimap: File,
     @Argument isHuman: Boolean,
     @Argument(required = false) intervalFile: Option[File] = None)
-      extends EightCoreJob {
+      extends SixteenCoreJob {
 
     this.isIntermediate = false
     override def jobRunnerJobName = projectName.get + "_qualimap"
@@ -289,14 +305,14 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
 
     override def commandLine =
       pathToQualimap + " " +
-        " --java-mem-size=20G " +
+        " --java-mem-size=" + this.memoryLimit.get.toInt.toString + "G " +
         " bamqc " +
         " -bam " + bam.getAbsolutePath() +
         gffString +
         " --paint-chromosome-limits " +
         " " + compareGCString + " " +
         " -outdir " + outputBase.getAbsolutePath() + "/" +
-        " -nt 8" +
+        " -nt " + this.coreLimit.toInt.toString +
         " &> " + logFile.getAbsolutePath()
 
   }

--- a/src/main/scala/molmed/utils/GeneralUtils.scala
+++ b/src/main/scala/molmed/utils/GeneralUtils.scala
@@ -17,6 +17,8 @@ import org.broadinstitute.gatk.queue.extensions.picard.ValidateSamFile
 import org.broadinstitute.gatk.queue.function.InProcessFunction
 import org.broadinstitute.gatk.queue.function.ListWriterFunction
 import org.broadinstitute.gatk.queue.util.StringFileConversions
+import org.broadinstitute.gatk.tools.walkers.bqsr.BQSRGatherer
+
 
 import htsjdk.samtools.SAMFileHeader.SortOrder
 import molmed.queue.extensions.RNAQC.RNASeQC
@@ -365,6 +367,24 @@ class GeneralUtils(projectName: Option[String], uppmaxConfig: UppmaxConfig) exte
     override def jobRunnerJobName = projectName.get + "_collectHSMetrics"
 
   }
+
+  /**
+   * Merge BQSR recalibration tables
+   *
+   * @param inRecalFiles Seq of recalibration table files to merge
+   * @param outRecalFile the merged output recalibration table file
+   */
+  case class mergeRecalibrationTables(@Input inRecalFiles: Seq[File], @Output outRecalFile: File, asIntermediate: Boolean = false) extends InProcessFunction {
+    import scala.collection.JavaConverters._
+
+    this.isIntermediate = asIntermediate
+
+    def run() {
+      new BQSRGatherer().gather(inRecalFiles.toList.asJava, outRecalFile)
+    }
+
+  }
+
 }
 
 /**

--- a/src/main/scala/molmed/utils/MergeFilesUtils.scala
+++ b/src/main/scala/molmed/utils/MergeFilesUtils.scala
@@ -31,7 +31,12 @@ class MergeFilesUtils(qscript: QScript, projectName: Option[String], uppmaxConfi
           qscript.add(joinBams(files, mergedFile, asIntermediate))
           mergedFile
         } else {
-          qscript.add(createLink(files(0), mergedFile, new File(files(0) + ".bai"), new File(mergedFile + ".bai"), asIntermediate))
+          qscript.add(
+            createLink(files(0),
+              mergedFile,
+              new File(files(0) + ".bai"),
+              GeneralUtils.swapExt(outputDir, mergedFile, ".bam", ".bam.bai"),
+              asIntermediate))
           mergedFile
         }
       }

--- a/src/main/scala/molmed/utils/SplitFilesAndMergeByChromosome.scala
+++ b/src/main/scala/molmed/utils/SplitFilesAndMergeByChromosome.scala
@@ -145,4 +145,27 @@ object SplitFilesAndMergeByChromosome {
     outBam
   }
 
+  /**
+   * Merge a set of recalibration table files
+   *
+   * @param qscript
+   * @param inRecalTables
+   * @param outRecalTable
+   * @param asIntermediate
+   * @param generalUtils
+   * @return The merged file
+   */
+  def mergeRecalibrationTables(
+    qscript: QScript,
+    inRecalTables: Seq[File],
+    outRecalTable: File,
+    asIntermediate: Boolean,
+    generalUtils: GeneralUtils): File = {
+
+    qscript.add(
+      generalUtils.mergeRecalibrationTables(inRecalTables, outRecalTable, asIntermediate = asIntermediate))
+
+    outRecalTable
+  }
+
 }

--- a/src/main/scala/molmed/utils/UppmaxJob.scala
+++ b/src/main/scala/molmed/utils/UppmaxJob.scala
@@ -19,44 +19,58 @@ class UppmaxJob(uppmaxConfig: UppmaxConfig) {
   def memLimit(memLimit: Option[Double]): Option[Double] = if (uppmaxConfig.testMode) Some(10) else memLimit
 
   trait OneCoreJob extends CommandLineFunction {
+    val coreLimit = 1
     this.jobNativeArgs = Seq("-p core -n 1") ++ projectBaseString
     this.memoryLimit = memLimit(Some(8))
     this.isIntermediate = false
   }
 
   trait TwoCoreJob extends CommandLineFunction {
+    val coreLimit = 2
     this.jobNativeArgs = Seq("-p core -n 2") ++ projectBaseString
     this.memoryLimit = memLimit(Some(16))
     this.isIntermediate = false
   }
 
   trait ThreeCoreJob extends CommandLineFunction {
+    val coreLimit = 3
     this.jobNativeArgs = Seq("-p core -n 3") ++ projectBaseString
     this.memoryLimit = memLimit(Some(24))
     this.isIntermediate = false
   }
 
   trait FourCoreJob extends CommandLineFunction {
+    val coreLimit = 4
     this.jobNativeArgs = Seq("-p core -n 4") ++ projectBaseString
     this.memoryLimit = memLimit(Some(32))
     this.isIntermediate = false
   }
 
   trait SixCoreJob extends CommandLineFunction {
+    val coreLimit = 6
     this.jobNativeArgs = Seq("-p core -n 6") ++ projectBaseString
     this.memoryLimit = memLimit(Some(48))
     this.isIntermediate = false
   }
 
   trait EightCoreJob extends CommandLineFunction {
+    val coreLimit = 8
     this.jobNativeArgs = Seq("-p core -n 8") ++ projectBaseString
     this.memoryLimit = memLimit(Some(64))
     this.isIntermediate = false
   }
 
+  trait TwelveCoreJob extends CommandLineFunction {
+    val coreLimit = 12
+    this.jobNativeArgs = Seq("-p core -n 12") ++ projectBaseString
+    this.memoryLimit = memLimit(Some(96))
+    this.isIntermediate = false
+  }
+
   trait SixteenCoreJob extends CommandLineFunction {
+    val coreLimit = 16
     this.jobNativeArgs = Seq("-p node") ++ projectBaseString
-    this.memoryLimit = memLimit(Some(128))
+    this.memoryLimit = memLimit(Some(112))
     this.isIntermediate = false
   }
 

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -16,7 +16,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param	qscript				the qscript to run the commandline wrappers in
  * @param variantCaller		The type of variant caller to use. Options are UnifiedGenotyper and HaplotypeCaller.
  * 							(default: HaplotypeCaller)
- * @param bams				the bam files to run on
+ * @param bamTargets				the bam file targets to run on
  * @param outputDir			output dir
  * @param runSeparatly		Create one vcf per bam sample instead of running on full cohort
  * @param isLowPass			true if low pass
@@ -33,10 +33,11 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param snpEffConfigPath  Path to snpEff config file
  * @param snpEffReference   The snpEff reference to use. E.g. "GRCh37.75"
  * @param skipAnnotation   Skip the annotation process
+ * @param skipVcfCompression    Skip compression of generated vcf files
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
-                                bams: Seq[File],
+                                bamTargets: Seq[GATKProcessingTarget],
                                 outputDir: File,
                                 runSeparatly: Boolean,
                                 isLowPass: Boolean,
@@ -52,4 +53,5 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffPath: Option[File] = None,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
-                                skipAnnotation: Boolean)
+                                skipAnnotation: Boolean,
+                                skipVcfCompression: Boolean)

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -54,4 +54,5 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
                                 skipAnnotation: Boolean,
-                                skipVcfCompression: Boolean)
+                                skipVcfCompression: Boolean,
+                                bcftoolsPath: Option[File] = None)

--- a/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -8,22 +8,24 @@ import java.io.File
 class VariantCallingTarget(outputDir: File,
                            val baseName: String,
                            val reference: File,
-                           val bamList: Seq[File],
+                           val bamTargetList: Seq[GATKProcessingTarget],
                            val intervals: Option[File],
                            val isLowpass: Boolean,
                            val isExome: Boolean,
                            val nSamples: Int,
-                           val snpGenotypingVcf: Option[File] = None) {
+                           val snpGenotypingVcf: Option[File] = None,
+                           val skipVcfCompression: Boolean = true) {
 
+  val vcfExtension = if (skipVcfCompression) "vcf" else "vcf.gz"
   val name = outputDir + "/" + baseName
   val clusterFile = new File(name + ".clusters")
-  val gVCFFile = new File(name + ".genomic.vcf")
-  val rawSnpVCF = new File(name + ".raw.snp.vcf")
-  val rawIndelVCF = new File(name + ".raw.indel.vcf")
-  val rawCombinedVariants = new File(name + ".raw.vcf")
-  val filteredIndelVCF = new File(name + ".filtered.indel.vcf")
-  val recalibratedSnpVCF = new File(name + ".recalibrated.snp.vcf")
-  val recalibratedIndelVCF = new File(name + ".recalibrated.indel.vcf")
+  val gVCFFile = new File(name + ".genomic." + vcfExtension)
+  val rawSnpVCF = new File(name + ".raw.snp." + vcfExtension)
+  val rawIndelVCF = new File(name + ".raw.indel." + vcfExtension)
+  val rawCombinedVariants = new File(name + ".raw." + vcfExtension)
+  val filteredIndelVCF = new File(name + ".filtered.indel." + vcfExtension)
+  val recalibratedSnpVCF = new File(name + ".recalibrated.snp." + vcfExtension)
+  val recalibratedIndelVCF = new File(name + ".recalibrated.indel." + vcfExtension)
   val tranchesSnpFile = new File(name + ".snp.tranches")
   val tranchesIndelFile = new File(name + ".indel.tranches")
   val vqsrSnpRscript: File = new File(name + ".snp.vqsr.r")
@@ -32,6 +34,5 @@ class VariantCallingTarget(outputDir: File,
   val recalIndelFile = new File(name + ".indel.tranches.recal")
   val evalFile = new File(name + ".snp.eval")
   val evalIndelFile = new File(name + ".indel.eval")
-  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")  
-  
+  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")
 }

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -99,13 +99,20 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     config.qscript.add(new SnpEvaluation(target, config.noRecal))
     config.qscript.add(new IndelEvaluation(target, config.noRecal))
 
-    Seq(
-      target.rawCombinedVariants,
-      target.recalibratedIndelVCF,
-      target.recalibratedSnpVCF,
-      target.evalFile,
-      target.evalIndelFile)
-
+    if (!config.noRecal) {
+      Seq(
+        target.rawCombinedVariants,
+        target.recalibratedIndelVCF,
+        target.recalibratedSnpVCF,
+        target.evalFile,
+        target.evalIndelFile)
+    }
+    else {
+      Seq(
+        target.rawCombinedVariants,
+        target.evalFile,
+        target.evalIndelFile)
+    }
   }
 
   /**

--- a/uppmax_global_config.xml
+++ b/uppmax_global_config.xml
@@ -51,6 +51,11 @@
             <path>/sw/apps/bioinfo/snpEff/4.1/nestor/scripts/snpEff</path>
 	    <version>4.1</version>
         </program>
+        <program>
+            <name>bcftools</name>
+            <path>/sw/apps/bioinfo/bcftools/1.2/nestor/bin/bcftools</path>
+            <version>1.2</version>
+        </program>
     </programs>
     <resources>
         <resource>


### PR DESCRIPTION
- gzip-compress all vcf files (with GATK) by default (implements #66)
- include the snpEff reference version in `version_report.txt` 
- Fixed typo in version report
- Fixed calls to snpEff (RAM, skip intermediate files, compress output)
- Option to include/exclude OQ, BD and BI tags during bam recalibration
- Option to remove recalibrated bam from final output
- Fixes to processing BAMs when splitting using ParallelShell
- Fixes to handling intermediate files and some un-annotated output files (mostly index files)
 