### PR TITLE
Explicitly pass bam file to genotype

### DIFF
--- a/piper/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/piper/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -398,7 +398,7 @@ class DNABestPracticeVariantCalling extends QScript
    * Variant calling
    */
   def runVariantCalling(
-    bamTargets: Seq[GATKProcessingTarget],
+    bams: Seq[File],
     outputDirectory: File,
     gatkOptions: GATKConfig,
     uppmaxConfig: UppmaxConfig): Seq[File] = {
@@ -415,7 +415,7 @@ class DNABestPracticeVariantCalling extends QScript
     val variantCallingConfig = new VariantCallingConfig(
       qscript = this,
       variantCaller = variantCallerToUse,
-      bamTargets,
+      bams,
       outputDirectory,
       runSeparatly,
       isLowPass,
@@ -573,7 +573,7 @@ class DNABestPracticeVariantCalling extends QScript
         gatkOptions, generalUtils, uppmaxConfig, reference)
 
     val variantCalling = runVariantCalling(
-      _: Seq[GATKProcessingTarget], variantCallsOutputDir,
+      _: Seq[File], variantCallsOutputDir,
       gatkOptions, uppmaxConfig)
 
     /**
@@ -618,7 +618,7 @@ class DNABestPracticeVariantCalling extends QScript
         val mergedBams = mergedAlignments(aligments)
         val processedBamTargets = dataProcessing(mergedBams)
         qualityControl(processedBamTargets.map( _.processedBam.file ), finalAlignmentQCOutputDir)
-        variantCalling(processedBamTargets)
+        variantCalling(processedBamTargets.map( _.recalBam.file ))
       }
       case e if e.contains(AnalysisSteps.GenerateDelivery) => {
 
@@ -632,7 +632,7 @@ class DNABestPracticeVariantCalling extends QScript
         val mergedBams = mergedAlignments(aligments)
         val processedBamTargets = dataProcessing(mergedBams)
         val finalQC = qualityControl(processedBamTargets.map( _.processedBam.file ), finalAlignmentQCOutputDir)
-        val variantCallFiles = variantCalling(processedBamTargets)
+        val variantCallFiles = variantCalling(processedBamTargets.map( _.recalBam.file ))
 
         runCreateDelivery(
           fastqs,

--- a/piper/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
+++ b/piper/src/main/scala/molmed/qscripts/legacy/VariantCalling.scala
@@ -121,14 +121,12 @@ class VariantCalling extends QScript with UppmaxXMLConfiguration {
     val variantCallingUtils = new VariantCallingUtils(gatkOptions, projectName, uppmaxConfig)
 
     val intervalOption = if(intervals == null) None else Some(intervals) 
-    
-    val bamTargets = bams.map( bam => new GATKProcessingTarget(outputDir, bam, skipDeduplication = false, gatkOptions.keepPreBQSRBam, intervalOption) )
-    
+
     val targets = (runSeparatly, notHuman) match {
-      case (true, false) => bamTargets.map(bamTarget => new VariantCallingTarget(outputDir, bamTarget.bam.getName(), reference, Seq(bamTarget), intervalOption, isLowpass, isExome, 1))
-      case (true, true) => bamTargets.map(bamTarget => new VariantCallingTarget(outputDir, bamTarget.bam.getName(), reference, Seq(bamTarget), intervalOption, isLowpass, false, 1))
-      case (false, true) => Seq(new VariantCallingTarget(outputDir, projectName.get, reference, bamTargets, intervalOption, isLowpass, false, bams.size))
-      case (false, false) => Seq(new VariantCallingTarget(outputDir, projectName.get, reference, bamTargets, intervalOption, isLowpass, isExome, bams.size))
+      case (true, false) => bams.map(bam => new VariantCallingTarget(outputDir, bam.getName, reference, Seq(bam), intervalOption, isLowpass, isExome, 1))
+      case (true, true) => bams.map(bam => new VariantCallingTarget(outputDir, bam.getName, reference, Seq(bam), intervalOption, isLowpass, false, 1))
+      case (false, true) => Seq(new VariantCallingTarget(outputDir, projectName.get, reference, bams, intervalOption, isLowpass, false, bams.size))
+      case (false, false) => Seq(new VariantCallingTarget(outputDir, projectName.get, reference, bams, intervalOption, isLowpass, isExome, bams.size))
     }
 
     for (target <- targets) {

--- a/piper/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/piper/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -75,17 +75,11 @@ class AlignmentQCUtils(
     skipVcfCompression: Boolean): Seq[File] = {
 
     val gatkOptionsWithGenotypingSnp = gatkOptions.copy(snpGenotypingVcf = Some(comparisonVcf))
-    val bamTargets = bamFiles.map( bamFile => new GATKProcessingTarget(
-          bamFile.getParentFile(),
-          bamFile,
-          skipDeduplication = false,
-          keepPreBQSRBam = false,
-          gatkOptions.intervalFile) )
     val variantCallingUtils = new VariantCallingUtils(gatkOptionsWithGenotypingSnp, projectName, uppmaxConfig)
     val variantCallingConfig = new VariantCallingConfig(
       qscript = qscript,
       variantCaller = Some(GATKUnifiedGenotyper),
-      bamTargets = bamTargets,
+      bams = bamFiles,
       outputDir = outputBase,
       runSeparatly = true,
       isLowPass = isLowPass,

--- a/piper/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/piper/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -16,7 +16,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param	qscript				the qscript to run the commandline wrappers in
  * @param variantCaller		The type of variant caller to use. Options are UnifiedGenotyper and HaplotypeCaller.
  * 							(default: HaplotypeCaller)
- * @param bamTargets				the bam file targets to run on
+ * @param bams				the bam files to run on
  * @param outputDir			output dir
  * @param runSeparatly		Create one vcf per bam sample instead of running on full cohort
  * @param isLowPass			true if low pass
@@ -37,7 +37,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
-                                bamTargets: Seq[GATKProcessingTarget],
+                                bams: Seq[File],
                                 outputDir: File,
                                 runSeparatly: Boolean,
                                 isLowPass: Boolean,

--- a/piper/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/piper/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -8,7 +8,7 @@ import java.io.File
 class VariantCallingTarget(outputDir: File,
                            val baseName: String,
                            val reference: File,
-                           val bamTargetList: Seq[GATKProcessingTarget],
+                           val bams: Seq[File],
                            val intervals: Option[File],
                            val isLowpass: Boolean,
                            val isExome: Boolean,

--- a/piper/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/piper/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -24,10 +24,10 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
   def checkGenotypeConcordance(config: VariantCallingConfig): Seq[File] = {
 
     val targets =
-      config.bamTargets.map(bamTarget => new VariantCallingTarget(config.outputDir,
-        bamTarget.bam.getName(),
+      config.bams.map(bam => new VariantCallingTarget(config.outputDir,
+        bam.getName,
         gatkOptions.reference,
-        Seq(bamTarget),
+        Seq(bam),
         gatkOptions.intervalFile,
         config.isLowPass, config.isExome, 1,
         snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
@@ -64,13 +64,13 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     // if the pipeline is set to run a combined analysis.
     if (target.nSamples > 1) {
       val gVcfFiles =
-        target.bamTargetList.map(bamTarget => {
+        target.bams.map(bam => {
 
           val modifiedTarget =
             new VariantCallingTarget(config.outputDir,
-              bamTarget.recalBam.file.getName(),
+              bam.getName,
               gatkOptions.reference,
-              Seq(bamTarget),
+              Seq(bam),
               gatkOptions.intervalFile,
               config.isLowPass, config.isExome, 1,
               skipVcfCompression = target.skipVcfCompression)
@@ -183,20 +183,20 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     // run together.
     val targets: Seq[VariantCallingTarget] = (config.runSeparatly, gatkOptions.notHuman) match {
       case (true, false) =>
-        config.bamTargets.map(bamTarget => new VariantCallingTarget(config.outputDir,
-          bamTarget.recalBam.file.getName(),
+        config.bams.map(bam => new VariantCallingTarget(config.outputDir,
+          bam.getName,
           gatkOptions.reference,
-          Seq(bamTarget),
+          Seq(bam),
           gatkOptions.intervalFile,
           config.isLowPass, config.isExome, 1,
           snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
           skipVcfCompression = config.skipVcfCompression))
 
       case (true, true) =>
-        config.bamTargets.map(bamTarget => new VariantCallingTarget(config.outputDir,
-          bamTarget.recalBam.file.getName(),
+        config.bams.map(bam => new VariantCallingTarget(config.outputDir,
+          bam.getName,
           gatkOptions.reference,
-          Seq(bamTarget),
+          Seq(bam),
           gatkOptions.intervalFile,
           config.isLowPass, false, 1,
           snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
@@ -206,9 +206,9 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
         Seq(new VariantCallingTarget(config.outputDir,
           projectName.get,
           gatkOptions.reference,
-          config.bamTargets,
+          config.bams,
           gatkOptions.intervalFile,
-          config.isLowPass, false, config.bamTargets.size,
+          config.isLowPass, false, config.bams.size,
           snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
           skipVcfCompression = config.skipVcfCompression))
 
@@ -216,9 +216,9 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
         Seq(new VariantCallingTarget(config.outputDir,
           projectName.get,
           gatkOptions.reference,
-          config.bamTargets,
+          config.bams,
           gatkOptions.intervalFile,
-          config.isLowPass, config.isExome, config.bamTargets.size,
+          config.isLowPass, config.isExome, config.bams.size,
           snpGenotypingVcf = gatkOptions.snpGenotypingVcf,
           skipVcfCompression = config.skipVcfCompression))
     }
@@ -293,7 +293,7 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     if (minimumBaseQuality.isDefined && minimumBaseQuality.get >= 0)
       this.min_base_quality_score = Some(min_base_quality_score.get.toByte)
 
-    this.input_file = t.bamTargetList.map( _.recalBam.file )
+    this.input_file = t.bams
     this.out = t.gVCFFile
 
     if (!gatkOptions.dbSNP.isEmpty)
@@ -392,7 +392,7 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     this.nt = gatkOptions.nbrOfThreads
     this.stand_call_conf = if (t.isLowpass) { Some(4.0) } else { Some(30.0) }
     this.stand_emit_conf = if (t.isLowpass) { Some(4.0) } else { Some(30.0) }
-    this.input_file = t.bamTargetList.map( _.recalBam.file )
+    this.input_file = t.bams
     if (!gatkOptions.dbSNP.isEmpty)
       this.D = gatkOptions.dbSNP.get
   }


### PR DESCRIPTION
This PR fixes an issue where the wrong bam file names were assumed for genotyping in the GenotypeConcordance check. This was due to bam files being wrapped inside `GATKProcessingTargets` and the genotyping method made assumptions of what file name to use for genotyping (the file resulting after processing). For the GenotypeConcordance check, genotyping is also done already on the raw alignments and this was not properly handled.

@johandahlberg, review and suggestions welcome. This has been tested on Milou, on chr22 of a CEPH sample using earlier pipeline-generated genotypes as the truth set.  