### PR TITLE
run clean as TwoCoreJob to allow more RAM, only separate indels and s…

### DIFF
--- a/piper/src/main/scala/molmed/utils/GATKUtils.scala
+++ b/piper/src/main/scala/molmed/utils/GATKUtils.scala
@@ -56,7 +56,7 @@ class GATKUtils(gatkOptions: GATKConfig, projectName: Option[String], uppmaxConf
 
   case class clean(inBams: Seq[File], tIntervals: File, outBam: File,
                    @Argument cleanModelEnum: ConsensusDeterminationModel,
-                   testMode: Boolean, asIntermediate: Boolean = true) extends IndelRealigner with CommandLineGATKArgs with OneCoreJob {
+                   testMode: Boolean, asIntermediate: Boolean = true) extends IndelRealigner with CommandLineGATKArgs with TwoCoreJob {
 
     this.isIntermediate = asIntermediate
 

--- a/piper/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/piper/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -105,20 +105,22 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
     // Evaluate the raw variants (both SNVs and INDELS)
     config.qscript.add(new CombinedEvaluation(target))
 
-    config.qscript.add(new SelectVariantType(target, SNPs, config.testMode))
-    config.qscript.add(new SelectVariantType(target, INDELs, config.testMode))
-
-    // Perform recalibration      
+    // Perform recalibration
     if (!config.noRecal) {
+
+      // Separate SNPs and INDELs and recalibrate and evaluate them individually
+      config.qscript.add(new SelectVariantType(target, SNPs, config.testMode))
+      config.qscript.add(new SelectVariantType(target, INDELs, config.testMode))
+
       config.qscript.add(new SnpRecalibration(target))
       config.qscript.add(new SnpCut(target))
 
       config.qscript.add(new IndelRecalibration(target))
       config.qscript.add(new IndelCut(target))
-    }
 
-    config.qscript.add(new SnpEvaluation(target, config.noRecal))
-    config.qscript.add(new IndelEvaluation(target, config.noRecal))
+      config.qscript.add(new SnpEvaluation(target, config.noRecal))
+      config.qscript.add(new IndelEvaluation(target, config.noRecal))
+    }
 
     if (!config.noRecal) {
       Seq(


### PR DESCRIPTION
…nps if actually doing recalibration

This PR introduces two changes:

- The amount of RAM assigned to the IndelRealigner step is doubled (corresponding to two cores)
- The raw vcf is only separated by snp and indels if recalibration of variant qualities is performed

Functionality has been verified on Milou.